### PR TITLE
Avatar class position tracking

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,7 @@ Checks: >
   -readability-magic-numbers,
   -modernize-use-trailing-return-type,
   -readability-implicit-bool-conversion,
+  -bugprone-easily-swappable-parameters,
 
 WarningsAsErrors: ''
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >
   -readability-identifier-length,
   -readability-magic-numbers,
   -modernize-use-trailing-return-type,
+  -readability-implicit-bool-conversion,
 
 WarningsAsErrors: ''
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -95,6 +95,11 @@ client-agent:
   # This should rarely need to be used.
   manual-dc-hash: 0xABCD1234
 
+  # The name of the "avatar" class that clients can own.
+  # This is only necessary if you want to take advantage of `setParentingRules`,
+  # and/or legacy shim chatting. Otherwise, this can be omitted.
+  avatar-class: DistributedPlayer
+
   # Shim's logins from Disney specific clients to an UberDOG.
   # (DoId matches AuthManager defined above.)
   # NOTE: You must build Ardos with ARDOS_USE_LEGACY_CLIENT to use this option.

--- a/src/clientagent/client_agent.cpp
+++ b/src/clientagent/client_agent.cpp
@@ -344,7 +344,7 @@ unsigned long ClientAgent::GetInterestTimeout() const {
  * Returns the configured avatar class (or nullptr if unset).
  * @return
  */
-DCClass *ClientAgent::GetAvatarClass() const { return _avatarClass; }
+DCClass* ClientAgent::GetAvatarClass() const { return _avatarClass; }
 
 /**
  * Called when a participant connects.

--- a/src/clientagent/client_agent.cpp
+++ b/src/clientagent/client_agent.cpp
@@ -149,6 +149,17 @@ ClientAgent::ClientAgent() {
     _interestTimeout = timeoutParam.as<unsigned long>();
   }
 
+  // Optional player avatar class configuration.
+  if (auto avatarClassParam = config["avatar-class"]) {
+    _avatarClass =
+        g_dc_file->get_class_by_name(avatarClassParam.as<std::string>());
+    if (!_avatarClass) {
+      spdlog::get("ca")->error("Configured avatar class: {} does not exist!",
+                               avatarClassParam.as<std::string>());
+      exit(1);
+    }
+  }
+
   // Channel allocation configuration.
   auto channelsParam = config["channels"];
   _nextChannel = channelsParam["min"].as<uint64_t>();
@@ -328,6 +339,12 @@ ClientAgent::GetInterestZoneRanges() const {
 unsigned long ClientAgent::GetInterestTimeout() const {
   return _interestTimeout;
 }
+
+/**
+ * Returns the configured avatar class (or nullptr if unset).
+ * @return
+ */
+DCClass *ClientAgent::GetAvatarClass() const { return _avatarClass; }
 
 /**
  * Called when a participant connects.

--- a/src/clientagent/client_agent.h
+++ b/src/clientagent/client_agent.h
@@ -60,6 +60,7 @@ class ClientAgent {
   [[nodiscard]] const std::vector<std::pair<uint32_t, uint32_t>>&
   GetInterestZoneRanges() const;
   [[nodiscard]] unsigned long GetInterestTimeout() const;
+  [[nodiscard]] DCClass *GetAvatarClass() const;
 
   void ParticipantJoined();
   void ParticipantLeft(ClientParticipant* client);
@@ -90,6 +91,7 @@ class ClientAgent {
   unsigned long _interestTimeout;
 
   std::unordered_map<uint32_t, Uberdog> _uberdogs;
+  DCClass *_avatarClass = nullptr;
 
   std::unordered_set<ClientParticipant*> _participants;
 

--- a/src/clientagent/client_agent.h
+++ b/src/clientagent/client_agent.h
@@ -60,7 +60,7 @@ class ClientAgent {
   [[nodiscard]] const std::vector<std::pair<uint32_t, uint32_t>>&
   GetInterestZoneRanges() const;
   [[nodiscard]] unsigned long GetInterestTimeout() const;
-  [[nodiscard]] DCClass *GetAvatarClass() const;
+  [[nodiscard]] DCClass* GetAvatarClass() const;
 
   void ParticipantJoined();
   void ParticipantLeft(ClientParticipant* client);
@@ -91,7 +91,7 @@ class ClientAgent {
   unsigned long _interestTimeout;
 
   std::unordered_map<uint32_t, Uberdog> _uberdogs;
-  DCClass *_avatarClass = nullptr;
+  DCClass* _avatarClass = nullptr;
 
   std::unordered_set<ClientParticipant*> _participants;
 

--- a/src/clientagent/client_participant.cpp
+++ b/src/clientagent/client_participant.cpp
@@ -1600,6 +1600,12 @@ void ClientParticipant::HandleAddOwnership(
 void ClientParticipant::HandleChangeLocation(const uint32_t& doId,
                                              const uint32_t& newParent,
                                              const uint32_t& newZone) {
+  // If the players avatar is changing location, make sure we keep track of it.
+  if (_avatarDoId == doId) {
+    _avatarParent = newParent;
+    _avatarZone = newZone;
+  }
+
   auto dg = std::make_shared<Datagram>();
   dg->AddUint16(CLIENT_OBJECT_LOCATION);
   dg->AddUint32(doId);

--- a/src/clientagent/client_participant.cpp
+++ b/src/clientagent/client_participant.cpp
@@ -323,7 +323,6 @@ void ClientParticipant::HandleDatagram(const std::shared_ptr<Datagram>& dg) {
             _channel, doId);
         break;
       }
-
       _declaredObjects.erase(doId);
       break;
     }
@@ -1441,8 +1440,14 @@ void ClientParticipant::HandleRemoveObject(const uint32_t& doId) {
   dg->AddUint32(doId);
   SendDatagram(dg);
 }
-
+  
 void ClientParticipant::HandleRemoveOwnership(const uint32_t& doId) {
+  if (_avatarDoId == doId) {
+    _avatarDoId = 0;
+    _avatarParent = 0;
+    _avatarZone = 0;
+  }
+
   auto dg = std::make_shared<Datagram>();
   dg->AddUint16(CLIENT_OBJECT_LEAVING_OWNER);
   dg->AddUint32(doId);
@@ -1541,6 +1546,14 @@ void ClientParticipant::HandleSetFields(const uint32_t& doId,
 void ClientParticipant::HandleAddOwnership(
     const uint32_t& doId, const uint32_t& parentId, const uint32_t& zoneId,
     const uint16_t& dcId, DatagramIterator& dgi, const bool& other) {
+  // Track location from the configured avatar class only.
+  DCClass *avatarClass = _clientAgent->GetAvatarClass();
+  if (avatarClass && _ownedObjects[doId].dcc == avatarClass) {
+    _avatarDoId = doId;
+    _avatarParent = parent;
+    _avatarZone = zone;
+  }
+
   auto dg = std::make_shared<Datagram>();
   spdlog::get("ca")->debug("Sending owner entry of object: {} to client: {}",
                            doId, _channel);

--- a/src/clientagent/client_participant.cpp
+++ b/src/clientagent/client_participant.cpp
@@ -20,7 +20,7 @@ static bool ZoneInConfiguredSet(const ClientAgent* agent, uint32_t zoneId) {
   return false;
 }
 
-static bool IsClassOrDerivedFrom(const DCClass *candidate, DCClass *baseClass) {
+static bool IsClassOrDerivedFrom(const DCClass* candidate, DCClass* baseClass) {
   if (!candidate || !baseClass) {
     return false;
   }
@@ -1069,6 +1069,9 @@ void ClientParticipant::HandleClientObjectUpdateField(DatagramIterator& dgi) {
                                            STATESERVER_OBJECT_SET_FIELD);
       dg->AddUint32(chatShim);
       dg->AddUint16(chatField->get_number());
+      // Send the clients avatar parentId/zoneId.
+      dg->AddUint32(_avatarParent);
+      dg->AddUint32(_avatarZone);
       // For whisper messages, add the target DoId (receiver.)
       if (field->get_name() == "setTalkWhisper") {
         dg->AddUint32(doId);
@@ -1458,12 +1461,12 @@ void ClientParticipant::HandleRemoveObject(const uint32_t& doId) {
   dg->AddUint32(doId);
   SendDatagram(dg);
 }
-  
+
 void ClientParticipant::HandleRemoveOwnership(const uint32_t& doId) {
   if (_avatarDoId == doId) {
-    _avatarDoId = 0;
-    _avatarParent = 0;
-    _avatarZone = 0;
+    _avatarDoId = INVALID_DO_ID;
+    _avatarParent = INVALID_DO_ID;
+    _avatarZone = INVALID_DO_ID;
   }
 
   auto dg = std::make_shared<Datagram>();
@@ -1565,11 +1568,11 @@ void ClientParticipant::HandleAddOwnership(
     const uint32_t& doId, const uint32_t& parentId, const uint32_t& zoneId,
     const uint16_t& dcId, DatagramIterator& dgi, const bool& other) {
   // Track location from the configured avatar class only.
-  DCClass *avatarClass = _clientAgent->GetAvatarClass();
+  DCClass* avatarClass = _clientAgent->GetAvatarClass();
   if (IsClassOrDerivedFrom(_ownedObjects[doId].dcc, avatarClass)) {
     _avatarDoId = doId;
-    _avatarParent = parent;
-    _avatarZone = zone;
+    _avatarParent = parentId;
+    _avatarZone = zoneId;
   }
 
   auto dg = std::make_shared<Datagram>();

--- a/src/clientagent/client_participant.cpp
+++ b/src/clientagent/client_participant.cpp
@@ -20,6 +20,24 @@ static bool ZoneInConfiguredSet(const ClientAgent* agent, uint32_t zoneId) {
   return false;
 }
 
+static bool IsClassOrDerivedFrom(const DCClass *candidate, DCClass *baseClass) {
+  if (!candidate || !baseClass) {
+    return false;
+  }
+  if (candidate == baseClass) {
+    return true;
+  }
+
+  const int parentCount = candidate->get_num_parents();
+  for (int i = 0; i < parentCount; ++i) {
+    if (IsClassOrDerivedFrom(candidate->get_parent(i), baseClass)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 ClientParticipant::ClientParticipant(
     ClientAgent* clientAgent, const std::shared_ptr<uvw::tcp_handle>& socket)
     : NetworkClient(socket), ChannelSubscriber(), _clientAgent(clientAgent) {
@@ -1548,7 +1566,7 @@ void ClientParticipant::HandleAddOwnership(
     const uint16_t& dcId, DatagramIterator& dgi, const bool& other) {
   // Track location from the configured avatar class only.
   DCClass *avatarClass = _clientAgent->GetAvatarClass();
-  if (avatarClass && _ownedObjects[doId].dcc == avatarClass) {
+  if (IsClassOrDerivedFrom(_ownedObjects[doId].dcc, avatarClass)) {
     _avatarDoId = doId;
     _avatarParent = parent;
     _avatarZone = zone;

--- a/src/clientagent/client_participant.h
+++ b/src/clientagent/client_participant.h
@@ -6,6 +6,7 @@
 #include "../net/network_client.h"
 #include "client_agent.h"
 #include "interest_operation.h"
+#include "../net/message_types.h"
 
 namespace Ardos {
 
@@ -170,10 +171,12 @@ class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
   // A map of DoId's to fields marked explicitly send-able.
   std::unordered_map<uint32_t, std::unordered_set<uint16_t>> _fieldsSendable;
 
-  // Tracked avatar ownership location from a configured avatar class.
-  uint32_t _avatarDoId = 0;
-  uint32_t _avatarParent = 0;
-  uint32_t _avatarZone = 0;
+  // Track owned avatar location for a configured avatar class.
+  // This is used primarily for setParentingRules, but is also used in legacy mode for
+  // chat handling/shimming (it's helpful to know *where* a message was sent from/to.)
+  uint32_t _avatarDoId = INVALID_DO_ID;
+  uint32_t _avatarParent = INVALID_DO_ID;
+  uint32_t _avatarZone = INVALID_DO_ID;
 
   // Context ID for handling interest responses from the state server.
   uint32_t _nextContext = 0;

--- a/src/clientagent/client_participant.h
+++ b/src/clientagent/client_participant.h
@@ -3,10 +3,10 @@
 
 #include "../messagedirector/channel_subscriber.h"
 #include "../net/datagram_iterator.h"
+#include "../net/message_types.h"
 #include "../net/network_client.h"
 #include "client_agent.h"
 #include "interest_operation.h"
-#include "../net/message_types.h"
 
 namespace Ardos {
 
@@ -172,8 +172,9 @@ class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
   std::unordered_map<uint32_t, std::unordered_set<uint16_t>> _fieldsSendable;
 
   // Track owned avatar location for a configured avatar class.
-  // This is used primarily for setParentingRules, but is also used in legacy mode for
-  // chat handling/shimming (it's helpful to know *where* a message was sent from/to.)
+  // This is used primarily for setParentingRules, but is also used in legacy
+  // mode for chat handling/shimming (it's helpful to know *where* a message was
+  // sent from/to.)
   uint32_t _avatarDoId = INVALID_DO_ID;
   uint32_t _avatarParent = INVALID_DO_ID;
   uint32_t _avatarZone = INVALID_DO_ID;

--- a/src/clientagent/client_participant.h
+++ b/src/clientagent/client_participant.h
@@ -59,6 +59,8 @@ class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
   [[nodiscard]] std::unordered_map<uint16_t, Interest> GetInterests() const {
     return _interests;
   }
+  [[nodiscard]] uint32_t GetAvatarParent() const { return _avatarParent; }
+  [[nodiscard]] uint32_t GetAvatarZone() const { return _avatarZone; }
 
  private:
   static uint64_t now_ms() { return uv_hrtime() / 1000000; }
@@ -167,6 +169,11 @@ class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
 
   // A map of DoId's to fields marked explicitly send-able.
   std::unordered_map<uint32_t, std::unordered_set<uint16_t>> _fieldsSendable;
+
+  // Tracked avatar ownership location from a configured avatar class.
+  uint32_t _avatarDoId = 0;
+  uint32_t _avatarParent = 0;
+  uint32_t _avatarZone = 0;
 
   // Context ID for handling interest responses from the state server.
   uint32_t _nextContext = 0;

--- a/src/messagedirector/message_director.cpp
+++ b/src/messagedirector/message_director.cpp
@@ -2,8 +2,6 @@
 
 #include <spdlog/sinks/stdout_color_sinks.h>
 
-#include <cstring>
-
 #include "../clientagent/client_agent.h"
 #ifdef ARDOS_WANT_DB_SERVER
 #include "../database/database_server.h"


### PR DESCRIPTION
Used for legacy chat shimming, but also very important for `setParentingRules` (future PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable avatar class for flexible avatar types
  * New accessors exposing avatar class and avatar location (parent & zone)

* **Bug Fixes / Behavior**
  * Improved avatar ownership tracking: clears on removal and only assigns for matching/derived avatar types
  * Chat messages now include avatar location context for talk/whisper
  * Initialization fails fast if a configured avatar class cannot be resolved

* **Chores**
  * Removed an unused include and updated lint config
<!-- end of auto-generated comment: release notes by coderabbit.ai -->