### PR TITLE
Optimize RabbitMQ routing

### DIFF
--- a/src/clientagent/client_participant.cpp
+++ b/src/clientagent/client_participant.cpp
@@ -40,7 +40,7 @@ static bool IsClassOrDerivedFrom(const DCClass* candidate, DCClass* baseClass) {
 
 ClientParticipant::ClientParticipant(
     ClientAgent* clientAgent, const std::shared_ptr<uvw::tcp_handle>& socket)
-    : NetworkClient(socket), ChannelSubscriber(), _clientAgent(clientAgent) {
+    : NetworkClient(socket), _clientAgent(clientAgent) {
   auto address = GetRemoteAddress();
   spdlog::get("ca")->debug("Client connected from {}:{}", address.ip,
                            address.port);

--- a/src/messagedirector/channel_subscriber.cpp
+++ b/src/messagedirector/channel_subscriber.cpp
@@ -11,8 +11,26 @@ namespace Ardos {
 std::unordered_map<std::string, unsigned int>
     ChannelSubscriber::_globalChannels =
         std::unordered_map<std::string, unsigned int>();
-std::map<ChannelRange, unsigned int> ChannelSubscriber::_globalRanges =
-    std::map<ChannelRange, unsigned int>();
+std::unordered_map<uint64_t, unsigned int> ChannelSubscriber::_globalBuckets =
+    std::unordered_map<uint64_t, unsigned int>();
+
+std::string ChannelSubscriber::BuildChannelRoutingKey(uint64_t channel) {
+  return "chan." + std::to_string(channel >> kChannelBucketShift) + "." +
+         std::to_string(channel);
+}
+
+std::string ChannelSubscriber::BuildBucketRoutingPattern(uint64_t bucket) {
+  return "chan." + std::to_string(bucket) + ".*";
+}
+
+uint64_t ChannelSubscriber::ChannelFromRoutingKey(
+    const std::string& routingKey) {
+  auto lastDot = routingKey.rfind('.');
+  if (lastDot == std::string::npos) {
+    return std::stoull(routingKey);
+  }
+  return std::stoull(routingKey.substr(lastDot + 1));
+}
 
 ChannelSubscriber::ChannelSubscriber() {
   // Fetch the global channel and our local queue.
@@ -25,19 +43,18 @@ ChannelSubscriber::ChannelSubscriber() {
 void ChannelSubscriber::Shutdown() {
   MessageDirector::Instance()->RemoveSubscriber(this);
 
-  // Cleanup our local channel subscriptions.
+  // Cleanup our local channel subscriptions. Unsubscribe* pops from the local
+  // list itself and also decrements the shared ref counts / tears down the
+  // RabbitMQ binding when the last subscriber drops -- so we must NOT pop
+  // beforehand, or the early-return on "not in _localChannels" kicks in and
+  // leaks the global state.
   while (!_localChannels.empty()) {
-    auto channel = std::stoull(_localChannels.back());
-    _localChannels.pop_back();
-
-    UnsubscribeChannel(channel);
+    UnsubscribeChannel(std::stoull(_localChannels.back()));
   }
 
-  // Cleanup our local range subscriptions.
+  // Same pattern for ranges.
   while (!_localRanges.empty()) {
     auto range = _localRanges.back();
-    _localRanges.pop_back();
-
     UnsubscribeRange(range.first, range.second);
   }
 }
@@ -61,7 +78,8 @@ void ChannelSubscriber::SubscribeChannel(const uint64_t& channel) {
   }
 
   // Otherwise, open the channel with RabbitMQ.
-  _globalChannel->bindQueue(kGlobalExchange, _localQueue, channelStr);
+  _globalChannel->bindQueue(kGlobalExchange, _localQueue,
+                            BuildChannelRoutingKey(channel));
 
   // ... and register it as a newly opened global channel.
   _globalChannels[channelStr] = 1;
@@ -86,7 +104,8 @@ void ChannelSubscriber::UnsubscribeChannel(const uint64_t& channel) {
   // longer care about it.
   if (!_globalChannels[channelStr]) {
     _globalChannels.erase(channelStr);
-    _globalChannel->unbindQueue(kGlobalExchange, _localQueue, channelStr);
+    _globalChannel->unbindQueue(kGlobalExchange, _localQueue,
+                                BuildChannelRoutingKey(channel));
   }
 }
 
@@ -101,15 +120,17 @@ void ChannelSubscriber::SubscribeRange(const uint64_t& min,
 
   _localRanges.push_back(range);
 
-  // Next, lets check if this channel range is already being listened to
-  // elsewhere. If it is, increment the subscriber count.
-  if (_globalRanges.contains(range)) {
-    _globalRanges[range]++;
-    return;
+  // Bind every bucket that overlaps this range. Over-delivery at the edges
+  // (channels inside the end buckets but outside [min, max]) is dropped by
+  // the client-side WithinLocalRange filter.
+  uint64_t minBucket = min >> kChannelBucketShift;
+  uint64_t maxBucket = max >> kChannelBucketShift;
+  for (uint64_t bucket = minBucket; bucket <= maxBucket; ++bucket) {
+    if (_globalBuckets[bucket]++ == 0) {
+      _globalChannel->bindQueue(kGlobalExchange, _localQueue,
+                                BuildBucketRoutingPattern(bucket));
+    }
   }
-
-  // Register it as a newly opened global channel range.
-  _globalRanges[range] = 1;
 }
 
 void ChannelSubscriber::UnsubscribeRange(const uint64_t& min,
@@ -123,13 +144,17 @@ void ChannelSubscriber::UnsubscribeRange(const uint64_t& min,
 
   _localRanges.erase(position);
 
-  // We can safely assume the channel range exists in a global context.
-  _globalRanges[range]--;
-
-  // If we have 0 current listeners for this channel range, let RabbitMQ know we
-  // no longer care about it.
-  if (!_globalRanges[range]) {
-    _globalRanges.erase(range);
+  // Release each bucket this range was holding. We only unbind from RabbitMQ
+  // once the per-bucket ref count drops to zero, so overlapping ranges from
+  // other subscribers keep their bindings alive.
+  uint64_t minBucket = min >> kChannelBucketShift;
+  uint64_t maxBucket = max >> kChannelBucketShift;
+  for (uint64_t bucket = minBucket; bucket <= maxBucket; ++bucket) {
+    if (--_globalBuckets[bucket] == 0) {
+      _globalBuckets.erase(bucket);
+      _globalChannel->unbindQueue(kGlobalExchange, _localQueue,
+                                  BuildBucketRoutingPattern(bucket));
+    }
   }
 }
 
@@ -139,18 +164,22 @@ void ChannelSubscriber::PublishDatagram(const std::shared_ptr<Datagram>& dg) {
   uint8_t channels = dgi.GetUint8();
   for (uint8_t i = 0; i < channels; ++i) {
     uint64_t channel = dgi.GetUint64();
-    _globalChannel->publish(kGlobalExchange, std::to_string(channel),
+    _globalChannel->publish(kGlobalExchange, BuildChannelRoutingKey(channel),
                             reinterpret_cast<const char*>(dg->GetData()),
                             (size_t)dg->Size());
   }
 }
 
-void ChannelSubscriber::HandleUpdate(const std::string& channel,
+void ChannelSubscriber::HandleUpdate(const std::string& routingKey,
                                      const std::shared_ptr<Datagram>& dg) {
+  // Routing keys look like `chan.<bucket>.<channel>`. Subscribers track
+  // channels by their raw ID string, so extract that portion first.
+  std::string channelStr = std::to_string(ChannelFromRoutingKey(routingKey));
+
   // First, check if this ChannelSubscriber cares about the message.
-  if (std::find(_localChannels.begin(), _localChannels.end(), channel) ==
+  if (std::find(_localChannels.begin(), _localChannels.end(), channelStr) ==
           _localChannels.end() &&
-      !WithinLocalRange(channel)) {
+      !WithinLocalRange(routingKey)) {
     return;
   }
 
@@ -159,7 +188,7 @@ void ChannelSubscriber::HandleUpdate(const std::string& channel,
 }
 
 bool ChannelSubscriber::WithinLocalRange(const std::string& routingKey) {
-  auto channel = std::stoull(routingKey);
+  auto channel = ChannelFromRoutingKey(routingKey);
   return std::any_of(
       _localRanges.begin(), _localRanges.end(),
       [channel](auto i) { return channel >= i.first && channel <= i.second; });

--- a/src/messagedirector/channel_subscriber.cpp
+++ b/src/messagedirector/channel_subscriber.cpp
@@ -8,9 +8,8 @@ namespace Ardos {
 // We use this to keep track of which channels we have opened with RabbitMQ.
 // Once a channel reaches a subscriber count of 0, we let RabbitMQ know that
 // we no longer wish to be routed messages about it.
-std::unordered_map<uint64_t, unsigned int>
-    ChannelSubscriber::_globalChannels =
-        std::unordered_map<uint64_t, unsigned int>();
+std::unordered_map<uint64_t, unsigned int> ChannelSubscriber::_globalChannels =
+    std::unordered_map<uint64_t, unsigned int>();
 std::unordered_map<uint64_t, unsigned int> ChannelSubscriber::_globalBuckets =
     std::unordered_map<uint64_t, unsigned int>();
 

--- a/src/messagedirector/channel_subscriber.cpp
+++ b/src/messagedirector/channel_subscriber.cpp
@@ -8,9 +8,9 @@ namespace Ardos {
 // We use this to keep track of which channels we have opened with RabbitMQ.
 // Once a channel reaches a subscriber count of 0, we let RabbitMQ know that
 // we no longer wish to be routed messages about it.
-std::unordered_map<std::string, unsigned int>
+std::unordered_map<uint64_t, unsigned int>
     ChannelSubscriber::_globalChannels =
-        std::unordered_map<std::string, unsigned int>();
+        std::unordered_map<uint64_t, unsigned int>();
 std::unordered_map<uint64_t, unsigned int> ChannelSubscriber::_globalBuckets =
     std::unordered_map<uint64_t, unsigned int>();
 
@@ -49,7 +49,7 @@ void ChannelSubscriber::Shutdown() {
   // beforehand, or the early-return on "not in _localChannels" kicks in and
   // leaks the global state.
   while (!_localChannels.empty()) {
-    UnsubscribeChannel(std::stoull(_localChannels.back()));
+    UnsubscribeChannel(*_localChannels.begin());
   }
 
   // Same pattern for ranges.
@@ -60,20 +60,15 @@ void ChannelSubscriber::Shutdown() {
 }
 
 void ChannelSubscriber::SubscribeChannel(const uint64_t& channel) {
-  std::string channelStr = std::to_string(channel);
-
   // Don't add duplicate channels.
-  if (std::find(_localChannels.begin(), _localChannels.end(), channelStr) !=
-      _localChannels.end()) {
+  if (!_localChannels.insert(channel).second) {
     return;
   }
 
-  _localChannels.push_back(channelStr);
-
   // Next, lets check if this channel is already being listened to elsewhere.
   // If it is, increment the subscriber count.
-  if (_globalChannels.contains(channelStr)) {
-    _globalChannels[channelStr]++;
+  if (_globalChannels.contains(channel)) {
+    _globalChannels[channel]++;
     return;
   }
 
@@ -82,28 +77,22 @@ void ChannelSubscriber::SubscribeChannel(const uint64_t& channel) {
                             BuildChannelRoutingKey(channel));
 
   // ... and register it as a newly opened global channel.
-  _globalChannels[channelStr] = 1;
+  _globalChannels[channel] = 1;
 }
 
 void ChannelSubscriber::UnsubscribeChannel(const uint64_t& channel) {
-  std::string channelStr = std::to_string(channel);
-
   // Make sure we've subscribed to this channel.
-  auto position =
-      std::find(_localChannels.begin(), _localChannels.end(), channelStr);
-  if (position == _localChannels.end()) {
+  if (!_localChannels.erase(channel)) {
     return;
   }
 
-  _localChannels.erase(position);
-
   // We can safely assume the channel exists in a global context.
-  _globalChannels[channelStr]--;
+  _globalChannels[channel]--;
 
   // If we have 0 current listeners for this channel, let RabbitMQ know we no
   // longer care about it.
-  if (!_globalChannels[channelStr]) {
-    _globalChannels.erase(channelStr);
+  if (!_globalChannels[channel]) {
+    _globalChannels.erase(channel);
     _globalChannel->unbindQueue(kGlobalExchange, _localQueue,
                                 BuildChannelRoutingKey(channel));
   }
@@ -161,25 +150,37 @@ void ChannelSubscriber::UnsubscribeRange(const uint64_t& min,
 void ChannelSubscriber::PublishDatagram(const std::shared_ptr<Datagram>& dg) {
   DatagramIterator dgi(dg);
 
+  // Tag every publish with our local queue name. The broker fans the message
+  // out to every bound queue including our own; the consume callback drops
+  // copies carrying this appID since we already delivered them in-process.
+  std::string localQueue = MessageDirector::Instance()->GetLocalQueue();
+
   uint8_t channels = dgi.GetUint8();
   for (uint8_t i = 0; i < channels; ++i) {
     uint64_t channel = dgi.GetUint64();
-    _globalChannel->publish(kGlobalExchange, BuildChannelRoutingKey(channel),
-                            reinterpret_cast<const char*>(dg->GetData()),
+    std::string routingKey = BuildChannelRoutingKey(channel);
+
+    // Deliver to in-process subscribers. Avoids the subscribe-then-publish
+    // race (async bindQueue not yet live) and skips the broker round-trip
+    // for traffic that never needed to leave this MD. DeliverLocally no-ops
+    // when nothing in this MD could match.
+    MessageDirector::Instance()->DeliverLocally(routingKey, dg);
+
+    AMQP::Envelope envelope(reinterpret_cast<const char*>(dg->GetData()),
                             (size_t)dg->Size());
+    envelope.setAppID(localQueue);
+    _globalChannel->publish(kGlobalExchange, routingKey, envelope);
   }
 }
 
 void ChannelSubscriber::HandleUpdate(const std::string& routingKey,
                                      const std::shared_ptr<Datagram>& dg) {
-  // Routing keys look like `chan.<bucket>.<channel>`. Subscribers track
-  // channels by their raw ID string, so extract that portion first.
-  std::string channelStr = std::to_string(ChannelFromRoutingKey(routingKey));
+  // Routing keys look like `chan.<bucket>.<channel>`; pull the channel out
+  // once for both the set lookup and the range check.
+  uint64_t channel = ChannelFromRoutingKey(routingKey);
 
   // First, check if this ChannelSubscriber cares about the message.
-  if (std::find(_localChannels.begin(), _localChannels.end(), channelStr) ==
-          _localChannels.end() &&
-      !WithinLocalRange(routingKey)) {
+  if (!_localChannels.contains(channel) && !WithinLocalRange(channel)) {
     return;
   }
 
@@ -187,8 +188,7 @@ void ChannelSubscriber::HandleUpdate(const std::string& routingKey,
   HandleDatagram(dg);
 }
 
-bool ChannelSubscriber::WithinLocalRange(const std::string& routingKey) {
-  auto channel = ChannelFromRoutingKey(routingKey);
+bool ChannelSubscriber::WithinLocalRange(uint64_t channel) {
   return std::any_of(
       _localRanges.begin(), _localRanges.end(),
       [channel](auto i) { return channel >= i.first && channel <= i.second; });

--- a/src/messagedirector/channel_subscriber.h
+++ b/src/messagedirector/channel_subscriber.h
@@ -12,6 +12,12 @@ namespace Ardos {
 
 typedef std::pair<uint64_t, uint64_t> ChannelRange;
 
+// Channels are bucketed by their upper bits so that range subscriptions can be
+// expressed as a small number of topic bindings of the form `chan.<bucket>.*`
+// rather than one binding per channel. With a 16-bit shift, each bucket covers
+// 65,536 channels, so a 200M-channel range is ~3,050 bindings.
+constexpr unsigned int kChannelBucketShift = 16;
+
 class ChannelSubscriber {
  public:
   friend class MessageDirector;
@@ -41,14 +47,20 @@ class ChannelSubscriber {
   virtual void HandleDatagram(const std::shared_ptr<Datagram>& dg) = 0;
 
  private:
-  void HandleUpdate(const std::string& channel,
+  void HandleUpdate(const std::string& routingKey,
                     const std::shared_ptr<Datagram>& dg);
 
   bool WithinLocalRange(const std::string& routingKey);
 
+  static std::string BuildChannelRoutingKey(uint64_t channel);
+  static std::string BuildBucketRoutingPattern(uint64_t bucket);
+  static uint64_t ChannelFromRoutingKey(const std::string& routingKey);
+
   // A static map of globally registered channels.
   static std::unordered_map<std::string, unsigned int> _globalChannels;
-  static std::map<ChannelRange, unsigned int> _globalRanges;
+  // Ref-counted bucket bindings. Multiple range subscriptions may overlap on
+  // the same bucket; we only unbind from RabbitMQ when the count hits zero.
+  static std::unordered_map<uint64_t, unsigned int> _globalBuckets;
 
   // List of channels that this ChannelSubscriber is listening to.
   std::vector<std::string> _localChannels;

--- a/src/messagedirector/channel_subscriber.h
+++ b/src/messagedirector/channel_subscriber.h
@@ -4,6 +4,7 @@
 #include <amqpcpp.h>
 
 #include <memory>
+#include <unordered_set>
 #include <utility>
 
 #include "../net/datagram.h"
@@ -39,7 +40,7 @@ class ChannelSubscriber {
    */
   void PublishDatagram(const std::shared_ptr<Datagram>& dg);
 
-  [[nodiscard]] std::vector<std::string> GetLocalChannels() const {
+  [[nodiscard]] const std::unordered_set<uint64_t>& GetLocalChannels() const {
     return _localChannels;
   }
 
@@ -50,20 +51,21 @@ class ChannelSubscriber {
   void HandleUpdate(const std::string& routingKey,
                     const std::shared_ptr<Datagram>& dg);
 
-  bool WithinLocalRange(const std::string& routingKey);
+  bool WithinLocalRange(uint64_t channel);
 
   static std::string BuildChannelRoutingKey(uint64_t channel);
   static std::string BuildBucketRoutingPattern(uint64_t bucket);
   static uint64_t ChannelFromRoutingKey(const std::string& routingKey);
 
   // A static map of globally registered channels.
-  static std::unordered_map<std::string, unsigned int> _globalChannels;
+  static std::unordered_map<uint64_t, unsigned int> _globalChannels;
   // Ref-counted bucket bindings. Multiple range subscriptions may overlap on
   // the same bucket; we only unbind from RabbitMQ when the count hits zero.
   static std::unordered_map<uint64_t, unsigned int> _globalBuckets;
 
-  // List of channels that this ChannelSubscriber is listening to.
-  std::vector<std::string> _localChannels;
+  // Channels this ChannelSubscriber is listening to. Hot-path membership
+  // check for every delivered message, hence unordered_set.
+  std::unordered_set<uint64_t> _localChannels;
   std::vector<ChannelRange> _localRanges;
 
   AMQP::Channel* _globalChannel;

--- a/src/messagedirector/message_director.cpp
+++ b/src/messagedirector/message_director.cpp
@@ -293,6 +293,37 @@ void MessageDirector::RemoveSubscriber(ChannelSubscriber* subscriber) {
 }
 
 /**
+ * Synchronously dispatches a datagram to in-process subscribers, bypassing
+ * RabbitMQ. Used by ChannelSubscriber::PublishDatagram so a subscribe-then-
+ * publish on the same channel doesn't race the async bindQueue, and so
+ * same-process traffic skips the broker round-trip entirely.
+ * @param routingKey
+ * @param dg
+ */
+void MessageDirector::DeliverLocally(const std::string& routingKey,
+                                     const std::shared_ptr<Datagram>& dg) {
+  // Mirror the safety-net check in StartConsuming's onReceived: skip the
+  // dispatch entirely if no binding in this MD could match.
+  uint64_t channel = ChannelSubscriber::ChannelFromRoutingKey(routingKey);
+  uint64_t bucket = channel >> kChannelBucketShift;
+  if (!ChannelSubscriber::_globalChannels.contains(channel) &&
+      !ChannelSubscriber::_globalBuckets.contains(bucket)) {
+    return;
+  }
+
+  for (const auto& subscriber : _subscribers) {
+    subscriber->HandleUpdate(routingKey, dg);
+  }
+
+  for (const auto& it : _leavingSubscribers) {
+    _subscribers.erase(it);
+    delete it;
+  }
+
+  _leavingSubscribers.clear();
+}
+
+/**
  * Called when a participant connects.
  */
 void MessageDirector::ParticipantJoined() {
@@ -371,6 +402,13 @@ void MessageDirector::StartConsuming() {
       .onSuccess([this](const std::string& tag) { _consumeTag = tag; })
       .onReceived([this](const AMQP::Message& message, uint64_t deliveryTag,
                          bool redelivered) {
+        // Drop loopback copies. PublishDatagram tags every outgoing message
+        // with our local queue name and delivers synchronously in-process;
+        // the broker still fans the message out to us, so ignore that copy.
+        if (message.hasAppID() && message.appID() == _localQueue) {
+          return;
+        }
+
         // Increment observed datagrams metric.
         if (_datagramsObservedCounter) {
           _datagramsObservedCounter->Increment();
@@ -383,8 +421,7 @@ void MessageDirector::StartConsuming() {
         uint64_t channel =
             ChannelSubscriber::ChannelFromRoutingKey(message.routingkey());
         uint64_t bucket = channel >> kChannelBucketShift;
-        if (!ChannelSubscriber::_globalChannels.contains(
-                std::to_string(channel)) &&
+        if (!ChannelSubscriber::_globalChannels.contains(channel) &&
             !ChannelSubscriber::_globalBuckets.contains(bucket)) {
           return;
         }

--- a/src/messagedirector/message_director.cpp
+++ b/src/messagedirector/message_director.cpp
@@ -169,7 +169,7 @@ void MessageDirector::onReady(AMQP::Connection* connection) {
 
   // Create our "global" exchange.
   _globalChannel = new AMQP::Channel(_connection);
-  _globalChannel->declareExchange(kGlobalExchange, AMQP::fanout)
+  _globalChannel->declareExchange(kGlobalExchange, AMQP::topic)
       .onSuccess([this]() {
         // Create our local queue.
         // This queue is specific to this process, and will be automatically
@@ -362,23 +362,30 @@ void MessageDirector::InitMetrics() {
  * Messages are handled by each Channel Subscriber.
  */
 void MessageDirector::StartConsuming() {
-  _globalChannel->consume(_localQueue)
+  // Consume in no-ack mode: the broker treats messages as acknowledged the
+  // moment they're delivered, which removes a round-trip per message and
+  // noticeably improves throughput. Trade-off: if this process dies mid-handle
+  // the in-flight message is lost, but the MD holds no durable state worth
+  // recovering -- the whole cluster re-converges on restart.
+  _globalChannel->consume(_localQueue, AMQP::noack)
       .onSuccess([this](const std::string& tag) { _consumeTag = tag; })
       .onReceived([this](const AMQP::Message& message, uint64_t deliveryTag,
                          bool redelivered) {
-        // Acknowledge the message.
-        _globalChannel->ack(deliveryTag);
-
         // Increment observed datagrams metric.
         if (_datagramsObservedCounter) {
           _datagramsObservedCounter->Increment();
         }
 
         // First, check if we have at least one channel subscriber listening to
-        // the channel in this cluster.
+        // the channel in this cluster. The topic exchange should only deliver
+        // messages matching one of our bindings, but keep the check as a
+        // safety net against spurious deliveries.
+        uint64_t channel =
+            ChannelSubscriber::ChannelFromRoutingKey(message.routingkey());
+        uint64_t bucket = channel >> kChannelBucketShift;
         if (!ChannelSubscriber::_globalChannels.contains(
-                message.routingkey()) &&
-            !WithinGlobalRange(message.routingkey())) {
+                std::to_string(channel)) &&
+            !ChannelSubscriber::_globalBuckets.contains(bucket)) {
           return;
         }
 
@@ -419,15 +426,6 @@ void MessageDirector::StartConsuming() {
       .onError([](const char* message) {
         spdlog::get("md")->error("Received error: {}", message);
       });
-}
-
-bool MessageDirector::WithinGlobalRange(const std::string& routingKey) {
-  auto channel = std::stoull(routingKey);
-  return std::any_of(ChannelSubscriber::_globalRanges.begin(),
-                     ChannelSubscriber::_globalRanges.end(), [channel](auto i) {
-                       return channel >= i.first.first &&
-                              channel <= i.first.second;
-                     });
 }
 
 void MessageDirector::HandleWeb(ws28::Client* client, nlohmann::json& data) {

--- a/src/messagedirector/message_director.cpp
+++ b/src/messagedirector/message_director.cpp
@@ -314,13 +314,6 @@ void MessageDirector::DeliverLocally(const std::string& routingKey,
   for (const auto& subscriber : _subscribers) {
     subscriber->HandleUpdate(routingKey, dg);
   }
-
-  for (const auto& it : _leavingSubscribers) {
-    _subscribers.erase(it);
-    delete it;
-  }
-
-  _leavingSubscribers.clear();
 }
 
 /**

--- a/src/messagedirector/message_director.h
+++ b/src/messagedirector/message_director.h
@@ -7,6 +7,7 @@
 #include <prometheus/histogram.h>
 #include <ws28/Client.h>
 
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <unordered_set>
 #include <uvw.hpp>
@@ -16,6 +17,7 @@ namespace Ardos {
 const std::string kGlobalExchange = "global-exchange";
 
 class ChannelSubscriber;
+class Datagram;
 class MDParticipant;
 
 class StateServer;
@@ -38,6 +40,9 @@ class MessageDirector : public AMQP::ConnectionHandler {
 
   void AddSubscriber(ChannelSubscriber* subscriber);
   void RemoveSubscriber(ChannelSubscriber* subscriber);
+
+  void DeliverLocally(const std::string& routingKey,
+                      const std::shared_ptr<Datagram>& dg);
 
   void ParticipantJoined();
   void ParticipantLeft(MDParticipant* participant);

--- a/src/messagedirector/message_director.h
+++ b/src/messagedirector/message_director.h
@@ -56,8 +56,6 @@ class MessageDirector : public AMQP::ConnectionHandler {
 
   void StartConsuming();
 
-  static bool WithinGlobalRange(const std::string& channel);
-
   static MessageDirector* _instance;
 
   std::unique_ptr<StateServer> _stateServer;

--- a/src/stateserver/distributed_object.cpp
+++ b/src/stateserver/distributed_object.cpp
@@ -660,6 +660,10 @@ void DistributedObject::HandleLocationChange(const uint32_t& newParent,
     return;
   }
 
+  // At this point the new parent (which may or may not be the same as the old
+  // parent) is unaware of our existence in this zone.
+  _parentSynchronized = false;
+
   // Send changing location message.
   auto dg = std::make_shared<Datagram>(targets, _doId,
                                        STATESERVER_OBJECT_CHANGING_LOCATION);
@@ -667,10 +671,6 @@ void DistributedObject::HandleLocationChange(const uint32_t& newParent,
   dg->AddLocation(newParent, newZone);
   dg->AddLocation(oldParent, oldZone);
   PublishDatagram(dg);
-
-  // At this point the new parent (which may or may not be the same as the old
-  // parent) is unaware of our existence in this zone.
-  _parentSynchronized = false;
 
   // Send enter location message.
   if (newParent) {


### PR DESCRIPTION
RabbitMQ routing logic was band-aid patched to support range subscription logic. This made every message a broadcast message, rather than a fanout, which means that every MD is spammed with `channels` they don't care about. The proposed fix is to modify the routing key to be as follows:

`chan.<bucket>.<channel>`

Where bucket is the channel id >> 16. This lets an MD subscribe to a range of channels much more efficiently (A range of 200m channels will be 3,050 bindings). This means that the DB/DBSS servers can subscribe with "chan.<bucket>.*" and effectively have efficient range-based routing logic. For normal channel subscriptions, the only overhead is computing which bucket the channel belongs in, but this negligible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Routing moved to bucketed/topic semantics for finer routing and reduced duplicate deliveries.
  * Subscription tracking reworked to handle overlapping ranges and simplify local storage.

* **New Features**
  * Added synchronous local delivery path for in-process subscribers.

* **Performance**
  * Consuming switched to broker-driven ack mode and added loopback filtering to reduce needless work.

* **Bug Fix**
  * Internal state update ordering adjusted to ensure consistent location-change handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->