### PR TITLE
WebSocket Client Agent Support

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -87,6 +87,10 @@ client-agent:
   host: 127.0.0.1
   port: 6667
 
+  # Transport protocol clients use to connect.
+  # Options are tcp (default) or ws (WebSocket).
+  transport: tcp
+
   # The logical version of the server.
   # This, along with the computed (or manual) DC hash, is used as a first point of contact to authenticate clients.
   version: dev

--- a/src/clientagent/client_agent.cpp
+++ b/src/clientagent/client_agent.cpp
@@ -216,7 +216,11 @@ ClientAgent::ClientAgent() {
   InitMetrics();
 
   // Start listening!
-  _listener->Listen(_host, _port);
+  if (!_listener->Listen(_host, _port)) {
+    spdlog::get("ca")->error("Failed to bind {} transport on {}:{}", _transport,
+                             _host, _port);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
+  }
 
   spdlog::get("ca")->info("Listening on {}:{} ({})", _host, _port, _transport);
 }

--- a/src/clientagent/client_agent.cpp
+++ b/src/clientagent/client_agent.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <string>
 
+#include "../net/tcp_transport.h"
+#include "../net/ws_transport.h"
 #include "../util/config.h"
 #include "../util/globals.h"
 #include "../util/logger.h"
@@ -16,8 +18,6 @@ namespace Ardos {
 
 ClientAgent::ClientAgent() {
   spdlog::info("Starting Client Agent component...");
-
-  _listenHandle = g_loop->resource<uvw::tcp_handle>();
 
   auto config = Config::Instance()->GetNode("client-agent");
 
@@ -34,6 +34,11 @@ ClientAgent::ClientAgent() {
   }
   if (auto portParam = config["port"]) {
     _port = portParam.as<int>();
+  }
+  // Transport selection. Defaults to TCP for backward compatibility;
+  // existing clients are unaffected. WS support is a thin ws28 wrapper.
+  if (auto transportParam = config["transport"]) {
+    _transport = transportParam.as<std::string>();
   }
 
   // Server version configuration.
@@ -188,18 +193,21 @@ ClientAgent::ClientAgent() {
     _udChatShim = chatShimParam.as<uint32_t>();
   }
 
-  // Socket events.
-  _listenHandle->on<uvw::listen_event>(
-      [this](const uvw::listen_event&, uvw::tcp_handle& srv) {
-        std::shared_ptr<uvw::tcp_handle> client =
-            srv.parent().resource<uvw::tcp_handle>();
-        srv.accept(*client);
+  // Build the transport listener based on config.
+  if (_transport == "tcp") {
+    _listener = std::make_unique<TcpTransportListener>();
+  } else if (_transport == "ws") {
+    _listener = std::make_unique<WsTransportListener>();
+  } else {
+    spdlog::get("ca")->error(
+        "Unknown transport '{}'. Supported values: tcp, ws", _transport);
+    exit(1);  // NOLINT(concurrency-mt-unsafe)
+  }
 
-        // Create a new client for this connected participant. The
-        // shared_ptr's ownership lives in MessageDirector::_subscribers
-        // (registered via Init); ClientAgent::_participants keeps a
-        // non-owning raw pointer for fast iteration.
-        auto participant = std::make_shared<ClientParticipant>(this, client);
+  _listener->SetConnectionFactory(
+      [this](std::unique_ptr<ITransportConnection> conn) {
+        auto participant =
+            std::make_shared<ClientParticipant>(this, std::move(conn));
         participant->Init();
         _participants.insert(participant.get());
       });
@@ -208,10 +216,9 @@ ClientAgent::ClientAgent() {
   InitMetrics();
 
   // Start listening!
-  _listenHandle->bind(_host, _port);
-  _listenHandle->listen();
+  _listener->Listen(_host, _port);
 
-  spdlog::get("ca")->info("Listening on {}:{}", _host, _port);
+  spdlog::get("ca")->info("Listening on {}:{} ({})", _host, _port, _transport);
 }
 
 /**

--- a/src/clientagent/client_agent.h
+++ b/src/clientagent/client_agent.h
@@ -25,14 +25,14 @@ struct Uberdog {
   bool anonymous;
 };
 
-enum InterestsPermission {
+enum InterestsPermission : std::uint8_t {
   INTERESTS_ENABLED,
   INTERESTS_VISIBLE,
   INTERESTS_DISABLED,
 };
 
 // Zone filter mode when interest.zones is configured (omitted = no filter).
-enum InterestMode {
+enum InterestMode : std::uint8_t {
   INTEREST_MODE_NONE,
   INTEREST_MODE_WHITELIST,
   INTEREST_MODE_BLACKLIST,

--- a/src/clientagent/client_agent.h
+++ b/src/clientagent/client_agent.h
@@ -15,6 +15,8 @@
 #include <uvw.hpp>
 #include <vector>
 
+#include "../net/transport.h"
+
 namespace Ardos {
 
 struct Uberdog {
@@ -74,10 +76,16 @@ class ClientAgent {
  private:
   void InitMetrics();
 
-  std::shared_ptr<uvw::tcp_handle> _listenHandle;
+  // Owns the listen socket / WS server. Concrete type selected at boot
+  // from the client-agent.transport config option (tcp | ws). All
+  // participants on this CA share one transport; mixed transports per
+  // CA aren't supported by design (run two CAs on different ports if
+  // you need both flavours).
+  std::unique_ptr<ITransportListener> _listener;
 
   std::string _host = "127.0.0.1";
   int _port = 6667;
+  std::string _transport = "tcp";
 
   std::string _version;
   uint32_t _dcHash;

--- a/src/clientagent/client_participant.cpp
+++ b/src/clientagent/client_participant.cpp
@@ -25,9 +25,9 @@ static bool IsClassOrDerivedFrom(const DCClass* candidate, DCClass* baseClass) {
 }
 
 ClientParticipant::ClientParticipant(
-    ClientAgent* clientAgent, const std::shared_ptr<uvw::tcp_handle>& socket)
-    : NetworkClient(socket), _clientAgent(clientAgent) {
-  auto address = GetRemoteAddress();
+    ClientAgent* clientAgent, std::unique_ptr<ITransportConnection> transport)
+    : _clientAgent(clientAgent), _transport(std::move(transport)) {
+  auto address = _transport->RemoteEndpoint();
   spdlog::get("ca")->debug("Client connected from {}:{}", address.ip,
                            address.port);
 }
@@ -37,6 +37,16 @@ void ClientParticipant::Init() {
   // identity even if channel allocation fails -- the disconnect path's
   // eventual Shutdown will then clean us up symmetrically.
   ChannelSubscriber::Init();  // AddSubscriber(shared_from_this())
+
+  // Bind ourselves as the transport's handler via a weak_ptr. Aliasing
+  // constructor reuses the ChannelSubscriber control block under a
+  // different typed pointer.
+  {
+    auto base = shared_from_this();
+    auto self = std::shared_ptr<ITransportHandler>(
+        base, static_cast<ITransportHandler*>(this));
+    _transport->SetHandler(std::weak_ptr<ITransportHandler>(self));
+  }
 
   _channel = _clientAgent->AllocateChannel();
   if (!_channel) {
@@ -113,11 +123,15 @@ void ClientParticipant::Shutdown() {
   if (_disconnected) {
     return;
   }
+  _disconnected = true;
 
   auto self = weak_from_this().lock();
 
-  // Kill the network connection.
-  NetworkClient::Shutdown();
+  // Close the transport. Idempotent; further OnTransport* callbacks
+  // become no-ops via the connection's internal closed flag.
+  if (_transport) {
+    _transport->Close();
+  }
 
   // Stop the heartbeat timer (if we have one.)
   if (_heartbeatTimer) {
@@ -207,16 +221,26 @@ void ClientParticipant::Shutdown() {
  * Handles socket disconnect events.
  * @param code
  */
-void ClientParticipant::HandleDisconnect(uv_errno_t code) {
+void ClientParticipant::OnTransportMessage(const uint8_t* data, size_t len) {
+  auto dg = std::make_shared<Datagram>(data, len);
+  HandleClientDatagram(dg);
+}
+
+void ClientParticipant::OnTransportDisconnect() {
   if (!_cleanDisconnect) {
     auto address = GetRemoteAddress();
-
-    auto errorEvent = uvw::error_event{(int)code};
-    spdlog::get("ca")->debug("Lost connection from {}:{}: {}", address.ip,
-                             address.port, errorEvent.what());
+    spdlog::get("ca")->debug("Lost connection from {}:{}", address.ip,
+                             address.port);
   }
 
   Shutdown();
+}
+
+void ClientParticipant::SendDatagram(const std::shared_ptr<Datagram>& dg) {
+  if (_disconnected || !_transport) {
+    return;
+  }
+  _transport->Send(dg->GetData(), dg->Size());
 }
 
 /**
@@ -224,7 +248,7 @@ void ClientParticipant::HandleDisconnect(uv_errno_t code) {
  * @param dg
  */
 void ClientParticipant::HandleDatagram(const std::shared_ptr<Datagram>& dg) {
-  if (Disconnected()) {
+  if (_disconnected) {
     return;
   }
 
@@ -247,7 +271,7 @@ void ClientParticipant::HandleDatagram(const std::shared_ptr<Datagram>& dg) {
     }
     case CLIENTAGENT_DROP: {
       _cleanDisconnect = true;
-      NetworkClient::Shutdown();
+      Shutdown();
       break;
     }
     case CLIENTAGENT_SET_STATE:
@@ -689,7 +713,7 @@ void ClientParticipant::HandleDatagram(const std::shared_ptr<Datagram>& dg) {
 void ClientParticipant::SendDisconnect(const uint16_t& reason,
                                        const std::string& message,
                                        const bool& security) {
-  if (Disconnected()) {
+  if (_disconnected) {
     return;
   }
 

--- a/src/clientagent/client_participant.h
+++ b/src/clientagent/client_participant.h
@@ -6,7 +6,7 @@
 #include "../messagedirector/channel_subscriber.h"
 #include "../net/datagram_iterator.h"
 #include "../net/message_types.h"
-#include "../net/network_client.h"
+#include "../net/transport.h"
 #include "client_agent.h"
 #include "interest_operation.h"
 #include "parenting_rule.h"
@@ -64,18 +64,24 @@ struct AvatarParentRule {
   uint16_t interestId;
 };
 
-class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
+class ClientParticipant final : public ITransportHandler,
+                                public ChannelSubscriber {
  public:
   ClientParticipant(ClientAgent* clientAgent,
-                    const std::shared_ptr<uvw::tcp_handle>& socket);
+                    std::unique_ptr<ITransportConnection> transport);
   ~ClientParticipant() override;
 
-  // Registers with the MessageDirector and starts auth/heartbeat/historical
-  // timers. Must be called immediately after construction (the factory at
-  // ClientAgent's listen handler does this) -- shared_from_this() is not
-  // valid in the constructor, and the timers want to capture a weak ref
-  // to ourselves so a late callback after destruction is a no-op.
+  // Registers with the MessageDirector, binds the transport handler,
+  // and starts auth/heartbeat/historical timers. Must be called by the
+  // factory immediately after construction so shared_from_this() works.
   void Init() override;
+
+  [[nodiscard]] TransportEndpoint GetRemoteAddress() const {
+    return _transport ? _transport->RemoteEndpoint() : TransportEndpoint{};
+  }
+  [[nodiscard]] TransportEndpoint GetLocalAddress() const {
+    return _transport ? _transport->LocalEndpoint() : TransportEndpoint{};
+  }
 
   friend class InterestOperation;
 
@@ -102,10 +108,19 @@ class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
 
   void Shutdown() override;
 
-  void HandleDisconnect(uv_errno_t code) override;
+  // ITransportHandler overrides. The transport delivers raw protocol
+  // payloads (framing already stripped); we wrap them in a Datagram and
+  // dispatch via HandleClientDatagram for the rest of the class.
+  void OnTransportMessage(const uint8_t* data, size_t len) override;
+  void OnTransportDisconnect() override;
 
-  void HandleClientDatagram(const std::shared_ptr<Datagram>& dg) override;
+  void HandleClientDatagram(const std::shared_ptr<Datagram>& dg);
   void HandleDatagram(const std::shared_ptr<Datagram>& dg) override;
+
+  // Outbound helper -- centralises every CLIENT_* send through the
+  // transport so the existing callers don't need to know whether they're
+  // talking to TCP or WS.
+  void SendDatagram(const std::shared_ptr<Datagram>& dg);
 
   void SendDisconnect(const uint16_t& reason, const std::string& message,
                       const bool& security = false);
@@ -207,6 +222,15 @@ class ClientParticipant final : public NetworkClient, public ChannelSubscriber {
   uint16_t AllocateInternalInterestId();
 
   ClientAgent* _clientAgent;
+
+  // Owning handle on the transport. Destructor closes the underlying
+  // socket / WS client. Cleared on transport disconnect so subsequent
+  // outbound writes become no-ops.
+  std::unique_ptr<ITransportConnection> _transport;
+
+  // Guards re-entrant Shutdown and short-circuits outbound sends on a
+  // closed connection.
+  bool _disconnected = false;
 
   uint64_t _channel;
   uint64_t _allocatedChannel;

--- a/src/clientagent/client_participant_remote.cpp
+++ b/src/clientagent/client_participant_remote.cpp
@@ -12,7 +12,7 @@ namespace Ardos {
  */
 void ClientParticipant::HandleClientDatagram(
     const std::shared_ptr<Datagram>& dg) {
-  if (Disconnected()) {
+  if (_disconnected) {
     return;
   }
 
@@ -189,7 +189,7 @@ void ClientParticipant::HandlePreAuth(DatagramIterator& dgi) {
   switch (msgType) {
     case CLIENT_DISCONNECT: {
       _cleanDisconnect = true;
-      NetworkClient::Shutdown();
+      Shutdown();
       break;
     }
     case CLIENT_OBJECT_SET_FIELD:
@@ -212,7 +212,7 @@ void ClientParticipant::HandleAuthenticated(DatagramIterator& dgi) {
   switch (msgType) {
     case CLIENT_DISCONNECT: {
       _cleanDisconnect = true;
-      NetworkClient::Shutdown();
+      Shutdown();
       break;
     }
     case CLIENT_OBJECT_SET_FIELD:

--- a/src/messagedirector/channel_subscriber.cpp
+++ b/src/messagedirector/channel_subscriber.cpp
@@ -42,9 +42,7 @@ uint64_t ChannelSubscriber::ChannelFromRoutingKey(
 }
 
 ChannelSubscriber::ChannelSubscriber() {
-  // Fetch the global channel and our local queue. We can't register with the
-  // MessageDirector here because shared_from_this() is not valid yet --
-  // subclass factories call Init() immediately after make_shared returns.
+  // MD registration happens in Init() -- shared_from_this() not valid here.
   _globalChannel = MessageDirector::Instance()->GetGlobalChannel();
   _localQueue = MessageDirector::Instance()->GetLocalQueue();
 }
@@ -70,20 +68,10 @@ void ChannelSubscriber::Init() {
 }
 
 void ChannelSubscriber::Shutdown() {
-  // Hold a self-reference for the duration of Shutdown. MessageDirector's
-  // _subscribers and our own _channelIndex/_bucketIndex each store
-  // shared_ptrs to us; the RemoveSubscriber + UnsubscribeChannel/Range
-  // calls below drop each of those refs one at a time, and on the last
-  // drop the destructor would otherwise run synchronously inside the
-  // erase that triggered it -- leaving Shutdown executing on freed
-  // memory. Anchoring a local shared_ptr keeps us alive until the
-  // method returns.
-  //
-  // weak_from_this().lock() returns null only when this Shutdown was
-  // invoked from a destructor that's already running (refcount is
-  // already 0). In that case there's nothing in the indexes to clean
-  // up anyway -- the prior external Shutdown call drained them -- so
-  // the loops below are no-ops and the null self is harmless.
+  // Anchor self for the duration of the method. RemoveSubscriber and
+  // each UnsubscribeChannel/Range below drops a shared_ptr ref; without
+  // this pin the last drop would destroy `this` inside the erase. Null
+  // when called from a destructor (indexes already drained, loops no-op).
   auto self = weak_from_this().lock();
 
   MessageDirector::Instance()->RemoveSubscriber(this);

--- a/src/messagedirector/channel_subscriber.h
+++ b/src/messagedirector/channel_subscriber.h
@@ -55,10 +55,10 @@ class ChannelSubscriber
   virtual void HandleDatagram(const std::shared_ptr<Datagram>& dg) = 0;
 
  private:
-  // Called by MessageDirector's dispatch path (channel/bucket index lookup
-  // hits us). The index already determined "do I care?" so HandleDatagram
-  // is invoked directly; the per-subscriber filter check that used to live
-  // in HandleUpdate has been retired.
+  // True if `channel` falls inside one of our subscribed ranges. The MD's
+  // bucket index narrows dispatch to range subscribers whose bucket
+  // matches; this is the per-subscriber range check that filters out
+  // over-delivery at the bucket edges.
   bool WithinLocalRange(uint64_t channel);
 
   static std::string BuildChannelRoutingKey(uint64_t channel);
@@ -71,17 +71,9 @@ class ChannelSubscriber
   // the same bucket; we only unbind from RabbitMQ when the count hits zero.
   static std::unordered_map<uint64_t, unsigned int> _globalBuckets;
 
-  // Routing-key dispatch index. Maps a channel (or bucket, for range
-  // subscriptions) to the set of subscribers that care about it. Dispatch
-  // looks up the index directly instead of iterating every subscriber and
-  // asking each one -- this turns the in-process delivery loop from O(N)
-  // to O(matching subscribers) per message.
-  //
-  // Populated by SubscribeChannel/SubscribeRange and drained by their
-  // Unsubscribe counterparts. Storing shared_ptr (rather than weak_ptr)
-  // keeps the index entries trivially hashable in unordered_set and adds
-  // one atomic refcount inc per subscription -- mirrored by the entry
-  // _subscribers already holds, so memory cost is negligible.
+  // Routing-key dispatch index: channel/bucket -> subscribers, so
+  // DeliverLocally is O(matching subscribers) instead of O(all
+  // subscribers). Maintained by Subscribe/UnsubscribeChannel/Range.
   static std::unordered_map<
       uint64_t, std::unordered_set<std::shared_ptr<ChannelSubscriber>>>
       _channelIndex;

--- a/src/messagedirector/message_director.cpp
+++ b/src/messagedirector/message_director.cpp
@@ -337,15 +337,10 @@ void MessageDirector::DeliverLocally(const std::string& routingKey,
   uint64_t channel = ChannelSubscriber::ChannelFromRoutingKey(routingKey);
   uint64_t bucket = channel >> kChannelBucketShift;
 
-  // Look up the interested subscribers via the routing-key index. Point
-  // subscribers (SubscribeChannel) hit _channelIndex directly; range
-  // subscribers (SubscribeRange) are indexed by bucket but a bucket can
-  // span channels outside the [min, max] they actually want, so we still
-  // call WithinLocalRange on those candidates.
-  //
-  // unordered_set dedupes the rare case where a subscriber has both a
-  // point sub on `channel` AND a range covering it, which previously
-  // resulted in one delivery via HandleUpdate's OR.
+  // Point subs hit _channelIndex directly; range subs are indexed by
+  // bucket and need WithinLocalRange to filter over-delivery at bucket
+  // edges. unordered_set dedupes subscribers carrying both a point sub
+  // and a covering range.
   std::unordered_set<std::shared_ptr<ChannelSubscriber>> interested;
 
   if (auto it = ChannelSubscriber::_channelIndex.find(channel);

--- a/src/messagedirector/message_director.h
+++ b/src/messagedirector/message_director.h
@@ -77,23 +77,14 @@ class MessageDirector : public AMQP::ConnectionHandler {
 
   static MessageDirector* _instance;
 
-  // The singletons that inherit from ChannelSubscriber (StateServer,
-  // DatabaseServer, DatabaseStateServer) are held by shared_ptr because
-  // they also live in _subscribers as shared_ptrs. Their lifetime is still
-  // effectively program-bound -- the MessageDirector holds the only owning
-  // ref outside _subscribers, so the second ref never causes confusion.
-  // ClientAgent does not inherit from ChannelSubscriber and stays unique.
+  // Singletons that also inherit ChannelSubscriber are shared_ptr so
+  // they can live in _subscribers; ClientAgent doesn't and stays unique.
   std::shared_ptr<StateServer> _stateServer;
   std::unique_ptr<ClientAgent> _clientAgent;
   std::shared_ptr<DatabaseServer> _db;
   std::shared_ptr<DatabaseStateServer> _dbss;
   std::unique_ptr<WebPanel> _webPanel;
 
-  // Shared ownership: each subscriber subclass is heap-allocated via
-  // make_shared and registered here. Dispatch snapshots this set (cheap
-  // shared_ptr copies), so a handler can safely drop the last "owning"
-  // reference mid-dispatch -- the snapshot keeps the object alive for
-  // the remainder of the loop.
   std::unordered_set<std::shared_ptr<ChannelSubscriber>> _subscribers;
   std::unordered_set<MDParticipant*> _participants;
 

--- a/src/net/tcp_transport.cpp
+++ b/src/net/tcp_transport.cpp
@@ -1,0 +1,194 @@
+#include "tcp_transport.h"
+
+#include <spdlog/spdlog.h>
+
+#include <cstring>
+
+#include "../util/globals.h"
+
+namespace Ardos {
+
+TcpTransportConnection::TcpTransportConnection(
+    std::shared_ptr<uvw::tcp_handle> socket)
+    : _socket(std::move(socket)) {
+  _socket->no_delay(true);
+  _socket->keep_alive(true, uvw::tcp_handle::time{60});
+
+  auto remote = _socket->peer();
+  auto local = _socket->sock();
+  _remoteEndpoint = {remote.ip, static_cast<uint16_t>(remote.port)};
+  _localEndpoint = {local.ip, static_cast<uint16_t>(local.port)};
+
+  // Wire libuv events. Every lambda captures `_alive` so a late-firing
+  // event after this connection has been closed becomes a no-op rather
+  // than dereferencing freed memory (uvw close() is async).
+  _socket->on<uvw::error_event>(
+      [this, alive = _alive](const uvw::error_event& event, uvw::tcp_handle&) {
+        if (!*alive) {
+          return;
+        }
+        HandleClose(event.code());
+      });
+
+  _socket->on<uvw::end_event>(
+      [this, alive = _alive](const uvw::end_event&, uvw::tcp_handle&) {
+        if (!*alive) {
+          return;
+        }
+        HandleClose(UV_EOF);
+      });
+
+  _socket->on<uvw::close_event>(
+      [this, alive = _alive](const uvw::close_event&, uvw::tcp_handle&) {
+        if (!*alive) {
+          return;
+        }
+        HandleClose(UV_EOF);
+      });
+
+  _socket->on<uvw::data_event>(
+      [this, alive = _alive](const uvw::data_event& event, uvw::tcp_handle&) {
+        if (!*alive) {
+          return;
+        }
+        HandleData(event.data, event.length);
+      });
+
+  _socket->on<uvw::write_event>(
+      [this, alive = _alive](const uvw::write_event&, uvw::tcp_handle&) {
+        if (!*alive) {
+          return;
+        }
+        if (_closed && !_socketClosed) {
+          _socket->close();
+          _socketClosed = true;
+        }
+        _isWriting = false;
+      });
+
+  _socket->read();
+}
+
+TcpTransportConnection::~TcpTransportConnection() { Close(); }
+
+void TcpTransportConnection::SetHandler(std::weak_ptr<ITransportHandler> h) {
+  _handler = std::move(h);
+}
+
+void TcpTransportConnection::Send(const uint8_t* data, size_t len,
+                                  Reliability /*r*/) {
+  // TCP is always reliable; the hint is ignored.
+  if (_closed || _socket == nullptr) {
+    return;
+  }
+
+  const size_t sendSize = sizeof(uint16_t) + len;
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> for uvw write
+  auto sendBuffer = std::unique_ptr<char[]>(new char[sendSize]);
+
+  const auto dgSize = static_cast<uint16_t>(len);
+  std::memcpy(sendBuffer.get(), &dgSize, sizeof(uint16_t));
+  std::memcpy(sendBuffer.get() + sizeof(uint16_t), data, len);
+
+  _isWriting = true;
+  _socket->write(std::move(sendBuffer), sendSize);
+}
+
+void TcpTransportConnection::Close() {
+  if (_closed) {
+    return;
+  }
+  *_alive = false;
+  _closed = true;
+
+  if (!_isWriting && !_socketClosed) {
+    _socket->close();
+    _socketClosed = true;
+  }
+}
+
+TransportEndpoint TcpTransportConnection::RemoteEndpoint() const {
+  return _remoteEndpoint;
+}
+
+TransportEndpoint TcpTransportConnection::LocalEndpoint() const {
+  return _localEndpoint;
+}
+
+void TcpTransportConnection::HandleClose(int /*err*/) {
+  if (_closed) {
+    return;
+  }
+  _closed = true;
+  _socketClosed = true;
+  *_alive = false;
+
+  if (auto handler = _handler.lock()) {
+    handler->OnTransportDisconnect();
+  }
+}
+
+void TcpTransportConnection::HandleData(const std::unique_ptr<char[]>& data,
+                                        size_t size) {
+  // Fast path: a single complete datagram in this chunk and no
+  // accumulator state. Avoids the buffer copy.
+  if (_readBuffer.empty() && size >= sizeof(uint16_t)) {
+    uint16_t dgSize;
+    std::memcpy(&dgSize, data.get(), sizeof(dgSize));
+    if (dgSize == size - sizeof(uint16_t)) {
+      DeliverMessage(
+          reinterpret_cast<const uint8_t*>(data.get() + sizeof(uint16_t)),
+          dgSize);
+      return;
+    }
+  }
+
+  _readBuffer.insert(_readBuffer.end(), data.get(), data.get() + size);
+  ProcessBuffer();
+}
+
+void TcpTransportConnection::ProcessBuffer() {
+  while (_readBuffer.size() > sizeof(uint16_t)) {
+    uint16_t dgSize;
+    std::memcpy(&dgSize, _readBuffer.data(), sizeof(dgSize));
+    if (_readBuffer.size() < dgSize + sizeof(uint16_t)) {
+      return;  // partial; wait for more bytes
+    }
+
+    DeliverMessage(_readBuffer.data() + sizeof(uint16_t), dgSize);
+    _readBuffer.erase(_readBuffer.begin(),
+                      _readBuffer.begin() + sizeof(uint16_t) + dgSize);
+  }
+}
+
+void TcpTransportConnection::DeliverMessage(const uint8_t* data, size_t len) {
+  if (auto handler = _handler.lock()) {
+    handler->OnTransportMessage(data, len);
+  }
+}
+
+TcpTransportListener::TcpTransportListener()
+    : _listenHandle(g_loop->resource<uvw::tcp_handle>()) {}
+
+void TcpTransportListener::SetConnectionFactory(ConnectionFactory factory) {
+  _factory = std::move(factory);
+}
+
+bool TcpTransportListener::Listen(const std::string& host, int port) {
+  _listenHandle->on<uvw::listen_event>(
+      [this](const uvw::listen_event&, uvw::tcp_handle& srv) {
+        if (!_factory) {
+          return;
+        }
+        std::shared_ptr<uvw::tcp_handle> client =
+            srv.parent().resource<uvw::tcp_handle>();
+        srv.accept(*client);
+        _factory(std::make_unique<TcpTransportConnection>(std::move(client)));
+      });
+
+  _listenHandle->bind(host, port);
+  _listenHandle->listen();
+  return true;
+}
+
+}  // namespace Ardos

--- a/src/net/tcp_transport.cpp
+++ b/src/net/tcp_transport.cpp
@@ -3,6 +3,7 @@
 #include <spdlog/spdlog.h>
 
 #include <cstring>
+#include <limits>
 
 #include "../util/globals.h"
 
@@ -16,8 +17,9 @@ TcpTransportConnection::TcpTransportConnection(
 
   auto remote = _socket->peer();
   auto local = _socket->sock();
-  _remoteEndpoint = {remote.ip, static_cast<uint16_t>(remote.port)};
-  _localEndpoint = {local.ip, static_cast<uint16_t>(local.port)};
+  _remoteEndpoint = {.ip = remote.ip,
+                     .port = static_cast<uint16_t>(remote.port)};
+  _localEndpoint = {.ip = local.ip, .port = static_cast<uint16_t>(local.port)};
 
   // Wire libuv events. Every lambda captures `_alive` so a late-firing
   // event after this connection has been closed becomes a no-op rather
@@ -69,7 +71,10 @@ TcpTransportConnection::TcpTransportConnection(
   _socket->read();
 }
 
-TcpTransportConnection::~TcpTransportConnection() { Close(); }
+TcpTransportConnection::~TcpTransportConnection() {
+  Close();
+  *_alive = false;
+}
 
 void TcpTransportConnection::SetHandler(std::weak_ptr<ITransportHandler> h) {
   _handler = std::move(h);
@@ -79,6 +84,14 @@ void TcpTransportConnection::Send(const uint8_t* data, size_t len,
                                   Reliability /*r*/) {
   // TCP is always reliable; the hint is ignored.
   if (_closed || _socket == nullptr) {
+    return;
+  }
+
+  // Framing prefix is uint16; larger payloads would wrap and corrupt.
+  if (len > std::numeric_limits<uint16_t>::max()) {
+    spdlog::get("ca")->error(
+        "TCP transport refusing oversized datagram ({}B > {}B max)", len,
+        std::numeric_limits<uint16_t>::max());
     return;
   }
 
@@ -98,9 +111,10 @@ void TcpTransportConnection::Close() {
   if (_closed) {
     return;
   }
-  *_alive = false;
   _closed = true;
 
+  // *_alive flips false only in the destructor; an in-flight write still
+  // needs the write_event lambda to run and close the socket.
   if (!_isWriting && !_socketClosed) {
     _socket->close();
     _socketClosed = true;
@@ -121,13 +135,13 @@ void TcpTransportConnection::HandleClose(int /*err*/) {
   }
   _closed = true;
   _socketClosed = true;
-  *_alive = false;
 
   if (auto handler = _handler.lock()) {
     handler->OnTransportDisconnect();
   }
 }
 
+// NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> from uvw read
 void TcpTransportConnection::HandleData(const std::unique_ptr<char[]>& data,
                                         size_t size) {
   // Fast path: a single complete datagram in this chunk and no

--- a/src/net/tcp_transport.h
+++ b/src/net/tcp_transport.h
@@ -26,6 +26,7 @@ class TcpTransportConnection final : public ITransportConnection {
 
  private:
   void HandleClose(int err);
+  // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> from uvw read
   void HandleData(const std::unique_ptr<char[]>& data, size_t size);
   void ProcessBuffer();
   void DeliverMessage(const uint8_t* data, size_t len);
@@ -42,10 +43,9 @@ class TcpTransportConnection final : public ITransportConnection {
   bool _isWriting = false;
   bool _socketClosed = false;
 
-  // Liveness flag captured by every uvw event lambda. uvw close() is
-  // async; a callback queued before close can still fire after this
-  // object has been destroyed. Setting *_alive=false in Close()
-  // short-circuits any such late events.
+  // Captured by every uvw event lambda; flipped false in the destructor
+  // so late-firing callbacks (uvw close() is async) no-op instead of
+  // accessing freed members on `this`.
   std::shared_ptr<bool> _alive = std::make_shared<bool>(true);
 };
 

--- a/src/net/tcp_transport.h
+++ b/src/net/tcp_transport.h
@@ -1,0 +1,70 @@
+#ifndef ARDOS_TCP_TRANSPORT_H
+#define ARDOS_TCP_TRANSPORT_H
+
+#include <memory>
+#include <string>
+#include <uvw.hpp>
+#include <vector>
+
+#include "transport.h"
+
+namespace Ardos {
+
+// libuv-backed TCP connection. Frames protocol datagrams over the byte
+// stream as [uint16 LE length][payload].
+class TcpTransportConnection final : public ITransportConnection {
+ public:
+  explicit TcpTransportConnection(std::shared_ptr<uvw::tcp_handle> socket);
+  ~TcpTransportConnection() override;
+
+  void SetHandler(std::weak_ptr<ITransportHandler> handler) override;
+  void Send(const uint8_t* data, size_t len,
+            Reliability r = Reliability::Reliable) override;
+  void Close() override;
+  [[nodiscard]] TransportEndpoint RemoteEndpoint() const override;
+  [[nodiscard]] TransportEndpoint LocalEndpoint() const override;
+
+ private:
+  void HandleClose(int err);
+  void HandleData(const std::unique_ptr<char[]>& data, size_t size);
+  void ProcessBuffer();
+  void DeliverMessage(const uint8_t* data, size_t len);
+
+  std::shared_ptr<uvw::tcp_handle> _socket;
+  std::weak_ptr<ITransportHandler> _handler;
+  TransportEndpoint _remoteEndpoint;
+  TransportEndpoint _localEndpoint;
+
+  // Accumulator for partial datagrams across uvw data_events.
+  std::vector<uint8_t> _readBuffer;
+
+  bool _closed = false;
+  bool _isWriting = false;
+  bool _socketClosed = false;
+
+  // Liveness flag captured by every uvw event lambda. uvw close() is
+  // async; a callback queued before close can still fire after this
+  // object has been destroyed. Setting *_alive=false in Close()
+  // short-circuits any such late events.
+  std::shared_ptr<bool> _alive = std::make_shared<bool>(true);
+};
+
+// Accepts inbound TCP connections via libuv. On accept, builds a
+// TcpTransportConnection and hands it to the configured factory (which
+// is expected to construct and Init() a ClientParticipant around it).
+class TcpTransportListener final : public ITransportListener {
+ public:
+  TcpTransportListener();
+  ~TcpTransportListener() override = default;
+
+  void SetConnectionFactory(ConnectionFactory factory) override;
+  bool Listen(const std::string& host, int port) override;
+
+ private:
+  std::shared_ptr<uvw::tcp_handle> _listenHandle;
+  ConnectionFactory _factory;
+};
+
+}  // namespace Ardos
+
+#endif  // ARDOS_TCP_TRANSPORT_H

--- a/src/net/transport.h
+++ b/src/net/transport.h
@@ -1,6 +1,7 @@
 #ifndef ARDOS_TRANSPORT_H
 #define ARDOS_TRANSPORT_H
 
+#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>

--- a/src/net/transport.h
+++ b/src/net/transport.h
@@ -1,0 +1,105 @@
+#ifndef ARDOS_TRANSPORT_H
+#define ARDOS_TRANSPORT_H
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace Ardos {
+
+// Reliability hint for transports that support multiple lanes (currently
+// only meaningful for GameNetworkingSockets in the future). TCP/WS always
+// deliver reliably and ignore the flag.
+enum class Reliability : std::uint8_t {
+  Reliable,
+  Unreliable,
+};
+
+// Network endpoint (ip + port). Transports that don't expose a meaningful
+// port (e.g. ws28 keeps only the peer IP) leave port=0.
+struct TransportEndpoint {
+  std::string ip;
+  std::uint16_t port = 0;
+};
+
+// Receives events from a transport. Implemented by ClientParticipant.
+//
+// The connection holds a weak_ptr to its handler so a destroyed handler
+// doesn't strand callbacks on freed memory -- if the handler has been
+// released, the connection's late events simply no-op.
+class ITransportHandler {
+ public:
+  virtual ~ITransportHandler() = default;
+
+  // One complete protocol datagram has been received from the peer. The
+  // transport has already stripped any transport-specific framing (TCP
+  // length prefix, WS frame header, etc.) -- the payload is the raw
+  // protocol message body.
+  virtual void OnTransportMessage(const uint8_t* data, size_t len) = 0;
+
+  // The peer closed the connection or the transport errored out. Called
+  // at most once per connection. The handler should treat this as the
+  // signal to release any resources tied to the connection.
+  virtual void OnTransportDisconnect() = 0;
+};
+
+// Per-connection transport handle owned by the per-connection handler
+// (typically ClientParticipant). Sending and closing are routed through
+// this; transport-specific framing/encoding lives in the implementation.
+class ITransportConnection {
+ public:
+  virtual ~ITransportConnection() = default;
+
+  // Bind the handler that receives this connection's events. Called once
+  // immediately after construction, from the handler's Init() (so that
+  // shared_from_this is valid). Subsequent OnTransportMessage /
+  // OnTransportDisconnect callbacks lock this weak_ptr; if it has
+  // expired, the events are dropped.
+  virtual void SetHandler(std::weak_ptr<ITransportHandler> handler) = 0;
+
+  // Send a single protocol datagram. The transport applies its own
+  // framing (length prefix for TCP, WS frame for WS). The reliability
+  // hint is passed through to transports that distinguish lanes; others
+  // ignore it.
+  virtual void Send(const uint8_t* data, size_t len,
+                    Reliability r = Reliability::Reliable) = 0;
+
+  // Close the connection. Idempotent. Triggers OnTransportDisconnect on
+  // the handler (asynchronously, after the underlying socket has been
+  // cleanly closed).
+  virtual void Close() = 0;
+
+  // Remote and local endpoints. Used for logging and for
+  // CLIENTAGENT_GET_NETWORK_ADDRESS_RESP. Transports without port info
+  // (WS for now) return port=0.
+  [[nodiscard]] virtual TransportEndpoint RemoteEndpoint() const = 0;
+  [[nodiscard]] virtual TransportEndpoint LocalEndpoint() const = 0;
+};
+
+// Accepts incoming connections on a host:port and dispatches each to a
+// factory that produces the per-connection handler. Concrete impls:
+// TcpTransportListener (libuv TCP) and WsTransportListener (ws28). The
+// listener owns the underlying socket / WS server; its lifetime is
+// bounded by the ClientAgent that created it.
+class ITransportListener {
+ public:
+  // Invoked on each accepted connection. Takes ownership of the
+  // connection; the listener retains no reference after the call.
+  using ConnectionFactory =
+      std::function<void(std::unique_ptr<ITransportConnection>)>;
+
+  virtual ~ITransportListener() = default;
+
+  virtual void SetConnectionFactory(ConnectionFactory factory) = 0;
+
+  // Start accepting connections. Returns true on success. On failure,
+  // the listener should log the reason and return false; the caller
+  // typically logs+exits since the role can't function without its
+  // listen socket.
+  virtual bool Listen(const std::string& host, int port) = 0;
+};
+
+}  // namespace Ardos
+
+#endif  // ARDOS_TRANSPORT_H

--- a/src/net/ws_transport.cpp
+++ b/src/net/ws_transport.cpp
@@ -12,7 +12,7 @@ namespace {
 // our static callbacks can find the listener and per-connection objects
 // without globals.
 
-void OnWsClientConnected(ws28::Client* client, ws28::HTTPRequest&) {
+void OnWsClientConnected(ws28::Client* client, ws28::HTTPRequest& /*req*/) {
   auto* server = client->GetServer();
   auto* listener = static_cast<WsTransportListener*>(server->GetUserData());
   if (!listener) {
@@ -58,7 +58,8 @@ void OnWsClientData(ws28::Client* client, char* data, size_t len,
 
 WsTransportConnection::WsTransportConnection(ws28::Client* client)
     : _client(client),
-      _remoteEndpoint{client->GetIP() ? client->GetIP() : "", 0} {}
+      _remoteEndpoint{.ip = client->GetIP() ? client->GetIP() : "", .port = 0} {
+}
 
 WsTransportConnection::~WsTransportConnection() {
   // If we still have a live ws28::Client pointer at destruction time
@@ -137,17 +138,24 @@ void WsTransportListener::SetConnectionFactory(ConnectionFactory factory) {
 }
 
 bool WsTransportListener::Listen(const std::string& host, int port) {
-  // ws28's framed message size cap. Match the same cap the rest of the
-  // protocol assumes (uint16 max for compatibility with TCP framing on
-  // the producer side). +2 leaves room for an optional inline length
-  // prefix if a client chooses to send one.
+  // ws28 binds all interfaces; host is advisory only on this transport.
+  if (!host.empty() && host != "0.0.0.0" && host != "::" &&
+      host != "127.0.0.1") {
+    spdlog::get("ca")->warn(
+        "WebSocket transport ignores host='{}'; ws28 binds all interfaces",
+        host);
+  }
+
+  // Max datagram is uint16 length + uint16-max payload = 0xFFFF + 2.
   _server->SetMaxMessageSize(0xFFFF + 2);
 
   // Disable Origin enforcement -- game clients aren't browsers and
   // don't carry meaningful Origin headers. (TLS isn't terminated here
   // anyway; reverse proxy handles cross-origin policy.)
   _server->SetCheckConnectionCallback(
-      [](ws28::Client*, ws28::HTTPRequest&) { return true; });
+      [](ws28::Client* /*client*/, ws28::HTTPRequest& /*req*/) {
+        return true;
+      });
 
   _server->SetClientConnectedCallback(&OnWsClientConnected);
   _server->SetClientDisconnectedCallback(&OnWsClientDisconnected);
@@ -162,8 +170,6 @@ bool WsTransportListener::Listen(const std::string& host, int port) {
                              port);
     return false;
   }
-
-  spdlog::get("ca")->info("WebSocket transport listening on {}:{}", host, port);
   return true;
 }
 

--- a/src/net/ws_transport.cpp
+++ b/src/net/ws_transport.cpp
@@ -1,0 +1,170 @@
+#include "ws_transport.h"
+
+#include <spdlog/spdlog.h>
+
+#include "../util/globals.h"
+
+namespace Ardos {
+
+namespace {
+
+// Threaded through ws28 via Server::SetUserData / Client::SetUserData so
+// our static callbacks can find the listener and per-connection objects
+// without globals.
+
+void OnWsClientConnected(ws28::Client* client, ws28::HTTPRequest&) {
+  auto* server = client->GetServer();
+  auto* listener = static_cast<WsTransportListener*>(server->GetUserData());
+  if (!listener) {
+    return;
+  }
+
+  auto conn = std::make_unique<WsTransportConnection>(client);
+  // Stash the raw connection pointer so subsequent data/disconnect
+  // callbacks can find it. Cleared in OnWsDisconnect/Close to prevent
+  // use-after-free if a stale callback fires after teardown.
+  client->SetUserData(conn.get());
+
+  // Hand the connection to the factory. After this call returns, the
+  // connection is owned by the handler (typically a ClientParticipant).
+  if (listener->Factory()) {
+    listener->Factory()(std::move(conn));
+  } else {
+    // No factory wired up; nothing to do but tear the client down.
+    client->SetUserData(nullptr);
+    client->Destroy();
+  }
+}
+
+void OnWsClientDisconnected(ws28::Client* client) {
+  auto* conn = static_cast<WsTransportConnection*>(client->GetUserData());
+  if (!conn) {
+    return;  // already torn down (e.g. via Close())
+  }
+  client->SetUserData(nullptr);
+  conn->OnWsDisconnect();
+}
+
+void OnWsClientData(ws28::Client* client, char* data, size_t len,
+                    int /*opcode*/) {
+  auto* conn = static_cast<WsTransportConnection*>(client->GetUserData());
+  if (!conn) {
+    return;
+  }
+  conn->OnWsData(reinterpret_cast<const uint8_t*>(data), len);
+}
+
+}  // namespace
+
+WsTransportConnection::WsTransportConnection(ws28::Client* client)
+    : _client(client),
+      _remoteEndpoint{client->GetIP() ? client->GetIP() : "", 0} {}
+
+WsTransportConnection::~WsTransportConnection() {
+  // If we still have a live ws28::Client pointer at destruction time
+  // (i.e. Close() / OnWsDisconnect() didn't already null it out), tear
+  // the underlying client down now. Detach our user-data pointer first
+  // so the resulting disconnected callback no-ops.
+  if (_client) {
+    auto* c = _client;
+    _client = nullptr;
+    c->SetUserData(nullptr);
+    c->Destroy();
+  }
+}
+
+void WsTransportConnection::SetHandler(std::weak_ptr<ITransportHandler> h) {
+  _handler = std::move(h);
+}
+
+void WsTransportConnection::Send(const uint8_t* data, size_t len,
+                                 Reliability /*r*/) {
+  // WS is always reliable; reliability hint is ignored. The third arg to
+  // ws28::Client::Send is the opcode: 2 = binary frame, which matches our
+  // datagram protocol.
+  if (_closed || !_client) {
+    return;
+  }
+  _client->Send(reinterpret_cast<const char*>(data), len, /*opCode=*/2);
+}
+
+void WsTransportConnection::Close() {
+  if (_closed) {
+    return;
+  }
+  _closed = true;
+  if (_client) {
+    auto* c = _client;
+    _client = nullptr;
+    c->SetUserData(nullptr);
+    c->Destroy();
+  }
+}
+
+TransportEndpoint WsTransportConnection::RemoteEndpoint() const {
+  return _remoteEndpoint;
+}
+
+TransportEndpoint WsTransportConnection::LocalEndpoint() const {
+  // ws28 doesn't surface the bound listen address per-client. Return an
+  // empty endpoint -- callers that need a non-empty local address should
+  // configure TCP or carry it via a config option.
+  return {};
+}
+
+void WsTransportConnection::OnWsData(const uint8_t* data, size_t len) {
+  if (auto handler = _handler.lock()) {
+    handler->OnTransportMessage(data, len);
+  }
+}
+
+void WsTransportConnection::OnWsDisconnect() {
+  // The ws28::Client is being destroyed; drop our pointer to it so any
+  // subsequent Send/Close calls become no-ops rather than dereferencing
+  // freed memory.
+  _client = nullptr;
+  _closed = true;
+  if (auto handler = _handler.lock()) {
+    handler->OnTransportDisconnect();
+  }
+}
+
+WsTransportListener::WsTransportListener()
+    : _server(std::make_unique<ws28::Server>(g_loop->raw())) {}
+
+void WsTransportListener::SetConnectionFactory(ConnectionFactory factory) {
+  _factory = std::move(factory);
+}
+
+bool WsTransportListener::Listen(const std::string& host, int port) {
+  // ws28's framed message size cap. Match the same cap the rest of the
+  // protocol assumes (uint16 max for compatibility with TCP framing on
+  // the producer side). +2 leaves room for an optional inline length
+  // prefix if a client chooses to send one.
+  _server->SetMaxMessageSize(0xFFFF + 2);
+
+  // Disable Origin enforcement -- game clients aren't browsers and
+  // don't carry meaningful Origin headers. (TLS isn't terminated here
+  // anyway; reverse proxy handles cross-origin policy.)
+  _server->SetCheckConnectionCallback(
+      [](ws28::Client*, ws28::HTTPRequest&) { return true; });
+
+  _server->SetClientConnectedCallback(&OnWsClientConnected);
+  _server->SetClientDisconnectedCallback(&OnWsClientDisconnected);
+  _server->SetClientDataCallback(&OnWsClientData);
+
+  // Stash `this` so the static callbacks above can find the listener
+  // via the ws28::Server they're handed.
+  _server->SetUserData(this);
+
+  if (!_server->Listen(port)) {
+    spdlog::get("ca")->error("WebSocket transport failed to bind port {}",
+                             port);
+    return false;
+  }
+
+  spdlog::get("ca")->info("WebSocket transport listening on {}:{}", host, port);
+  return true;
+}
+
+}  // namespace Ardos

--- a/src/net/ws_transport.h
+++ b/src/net/ws_transport.h
@@ -1,0 +1,66 @@
+#ifndef ARDOS_WS_TRANSPORT_H
+#define ARDOS_WS_TRANSPORT_H
+
+#include <ws28/Server.h>
+
+#include <memory>
+#include <string>
+
+#include "transport.h"
+
+namespace Ardos {
+
+// WebSocket connection wrapping a ws28::Client. ws28 owns the Client; we
+// hold a raw pointer nulled on disconnect/Close so subsequent Send/Close
+// calls no-op. Each datagram is sent as one binary WS frame -- no length
+// prefix on the wire, the frame is the boundary.
+class WsTransportConnection final : public ITransportConnection {
+ public:
+  explicit WsTransportConnection(ws28::Client* client);
+  ~WsTransportConnection() override;
+
+  void SetHandler(std::weak_ptr<ITransportHandler> handler) override;
+  void Send(const uint8_t* data, size_t len,
+            Reliability r = Reliability::Reliable) override;
+  void Close() override;
+  [[nodiscard]] TransportEndpoint RemoteEndpoint() const override;
+  [[nodiscard]] TransportEndpoint LocalEndpoint() const override;
+
+  // Called by the listener's static ws28 callbacks (via the user-data
+  // pointer stashed on the ws28::Client at construction).
+  void OnWsData(const uint8_t* data, size_t len);
+  void OnWsDisconnect();
+
+ private:
+  ws28::Client* _client;  // ws28::Server owns; nulled on disconnect/close
+  std::weak_ptr<ITransportHandler> _handler;
+  // ws28 surfaces only the peer IP, not port. Port is therefore 0; the
+  // local endpoint is similarly empty (ws28 doesn't expose the listen
+  // socket's bound port through its Client API). The GET_NETWORK_ADDRESS
+  // response will carry the IP correctly and zeroes for the ports.
+  TransportEndpoint _remoteEndpoint;
+  bool _closed = false;
+};
+
+// ws28-backed WebSocket listener. Wraps each inbound ws28::Client in a
+// WsTransportConnection and hands it to the configured factory.
+class WsTransportListener final : public ITransportListener {
+ public:
+  WsTransportListener();
+  ~WsTransportListener() override = default;
+
+  void SetConnectionFactory(ConnectionFactory factory) override;
+  bool Listen(const std::string& host, int port) override;
+
+  // Accessor for the static ws28 callbacks (they receive a ws28::Server*
+  // and reach back into us via Server::GetUserData()).
+  [[nodiscard]] const ConnectionFactory& Factory() const { return _factory; }
+
+ private:
+  std::unique_ptr<ws28::Server> _server;
+  ConnectionFactory _factory;
+};
+
+}  // namespace Ardos
+
+#endif  // ARDOS_WS_TRANSPORT_H

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -8,3 +8,4 @@ pika>=1.3
 pymongo>=4.6
 gcovr>=7.0
 black>=24.0
+websocket-client>=1.6

--- a/tests/test_clientagent_ws.py
+++ b/tests/test_clientagent_ws.py
@@ -1,0 +1,74 @@
+"""WebSocket transport smoke test.
+
+The Client Agent's transport backend is configurable via the
+``client-agent.transport`` config option. This file proves the WS
+transport delivers protocol datagrams end-to-end: a Python WS client
+connects, sends CLIENT_HELLO, and receives CLIENT_HELLO_RESP.
+
+Wire format note: over WS each protocol datagram is a single binary
+frame. There is no ``[uint16 length]`` prefix on the wire -- the WS
+frame itself is the boundary. (Over TCP we still prepend the length
+prefix because TCP is a byte stream; the framing decision lives inside
+each transport implementation, not in the protocol layer.)
+"""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+import websocket
+
+from tests.common.ardos import Datagram, DatagramIterator
+from tests.common.dc import dc_hash
+from tests.common.msgtypes import CLIENT_HELLO, CLIENT_HELLO_RESP
+
+
+@pytest.fixture
+def ca_ws(ardos):
+    """CA configured to listen over WebSockets instead of plain TCP."""
+    return ardos(
+        md=True,
+        ss=True,
+        ca=True,
+        overrides={"client-agent": {"transport": "ws"}},
+    )
+
+
+def test_ws_hello_handshake(ca_ws):
+    """The WS transport accepts a CLIENT_HELLO sent as a binary frame and
+    responds with CLIENT_HELLO_RESP on the same connection. This is the
+    end-to-end proof that ITransportListener+ITransportConnection routing
+    works under ws28, without duplicating the full TCP test suite -- the
+    rest of the protocol is transport-agnostic by design.
+    """
+    ws = websocket.create_connection(
+        "ws://127.0.0.1:6667/", subprotocols=[], timeout=5.0
+    )
+    try:
+        # CLIENT_HELLO payload: [uint16 msgtype][uint32 dc_hash][string version]
+        payload = (
+            Datagram()
+            .add_uint16(CLIENT_HELLO)
+            .add_uint32(dc_hash("test.dc"))
+            .add_string("dev")
+            .bytes()
+        )
+        # WS framing: send the payload as a single binary frame. No
+        # length prefix -- the WS frame IS the boundary.
+        ws.send_binary(payload)
+
+        # Receive the response. websocket-client gives us the complete
+        # frame as bytes.
+        resp = ws.recv()
+        assert isinstance(resp, (bytes, bytearray)), (
+            f"expected binary frame; got {type(resp).__name__}"
+        )
+
+        it = DatagramIterator(bytes(resp))
+        mt = it.read_uint16()
+        assert mt == CLIENT_HELLO_RESP, (
+            f"expected CLIENT_HELLO_RESP ({CLIENT_HELLO_RESP}); got {mt}"
+        )
+    finally:
+        ws.close()

--- a/tests/test_clientagent_ws.py
+++ b/tests/test_clientagent_ws.py
@@ -61,14 +61,14 @@ def test_ws_hello_handshake(ca_ws):
         # Receive the response. websocket-client gives us the complete
         # frame as bytes.
         resp = ws.recv()
-        assert isinstance(resp, (bytes, bytearray)), (
-            f"expected binary frame; got {type(resp).__name__}"
-        )
+        assert isinstance(
+            resp, (bytes, bytearray)
+        ), f"expected binary frame; got {type(resp).__name__}"
 
         it = DatagramIterator(bytes(resp))
         mt = it.read_uint16()
-        assert mt == CLIENT_HELLO_RESP, (
-            f"expected CLIENT_HELLO_RESP ({CLIENT_HELLO_RESP}); got {mt}"
-        )
+        assert (
+            mt == CLIENT_HELLO_RESP
+        ), f"expected CLIENT_HELLO_RESP ({CLIENT_HELLO_RESP}); got {mt}"
     finally:
         ws.close()


### PR DESCRIPTION
Native support for a WebSocket CA allow web-based games to connect to Ardos directly without the need for a WS <-> TCP proxy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Client Agent supports selectable transports (TCP or WebSocket) via configuration.
  * New transport layer implementations provide framed TCP and WebSocket messaging with safer connection lifecycles and endpoint visibility.

* **Documentation**
  * Configuration example updated to expose the client-agent.transport setting.

* **Tests**
  * Added WebSocket smoke test verifying end-to-end handshake and message exchange.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ksmit799/Ardos/pull/44)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->