### PR TITLE
Fix daemon stall at high CA participant counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
         ports:
           - 5672:5672
           - 15672:15672
+        env:
+          # See docker-compose.test.yml for rationale. Keep in sync.
+          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit credit_flow_default_credit {20000,10000}"
         options: >-
           --health-cmd "rabbitmq-diagnostics -q ping"
           --health-interval 5s

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install build tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake tar git zip unzip curl pkg-config
+          sudo apt-get install -y build-essential cmake tar git zip unzip curl pkg-config libc6-dbg
 
       - name: Build Ardos
         run: |

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -92,8 +92,8 @@ jobs:
             sudo sysctl -w kernel.yama.ptrace_scope=0
             pytest tests/benchmarks/ --codspeed -v --timeout=600
 
-      - name: Upload daemon logs on failure
-        if: failure()
+      - name: Upload daemon logs
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: daemon-logs

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -27,6 +27,9 @@ jobs:
         ports:
           - 5672:5672
           - 15672:15672
+        env:
+          # See docker-compose.test.yml for rationale. Keep in sync.
+          RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit credit_flow_default_credit {20000,10000}"
         options: >-
           --health-cmd "rabbitmq-diagnostics -q ping"
           --health-interval 5s
@@ -86,7 +89,7 @@ jobs:
 
       - name: Upload daemon logs on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: daemon-logs
           path: tests/logs/

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -85,6 +85,11 @@ jobs:
           run: |
             ulimit -n 65535
             sudo sysctl -w net.core.somaxconn=4096
+            # Allow the bench_monitor (a sibling process to the daemon) to
+            # read /proc/PID/task/TID/stack for diagnostic captures. Default
+            # ptrace_scope=1 restricts to parent processes; pytest is parent
+            # of both processes so the monitor can't peek without this.
+            sudo sysctl -w kernel.yama.ptrace_scope=0
             pytest tests/benchmarks/ --codspeed -v --timeout=600
 
       - name: Upload daemon logs on failure

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -5,6 +5,14 @@ services:
     ports:
       - "5672:5672"
       - "15672:15672"
+    environment:
+      # Raise per-channel credit-flow window from the default {400, 200}.
+      # Ardos publishes in bursts (zone broadcasts, cluster restart storms)
+      # that easily exceed 400 frames in a single tick; the default window
+      # throttles the publisher mid-burst, which under high subscriber
+      # counts can wedge the libuv loop. {20000, 10000} comfortably absorbs
+      # a 10k-client broadcast iteration without engaging flow control.
+      RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit credit_flow_default_credit {20000,10000}"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]
       interval: 5s

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,10 +8,9 @@ services:
     environment:
       # Raise per-channel credit-flow window from the default {400, 200}.
       # Ardos publishes in bursts (zone broadcasts, cluster restart storms)
-      # that easily exceed 400 frames in a single tick; the default window
-      # throttles the publisher mid-burst, which under high subscriber
-      # counts can wedge the libuv loop. {20000, 10000} comfortably absorbs
-      # a 10k-client broadcast iteration without engaging flow control.
+      # that easily exceed 400 frames in a single tick and would otherwise
+      # be throttled mid-burst. {20000, 10000} comfortably absorbs a
+      # 10k-client broadcast iteration without engaging flow control.
       RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS: "-rabbit credit_flow_default_credit {20000,10000}"
     healthcheck:
       test: ["CMD", "rabbitmq-diagnostics", "ping"]

--- a/src/net/network_client.cpp
+++ b/src/net/network_client.cpp
@@ -3,6 +3,7 @@
 #include <spdlog/spdlog.h>
 
 #include <cstring>
+#include <limits>
 
 namespace Ardos {
 
@@ -44,7 +45,7 @@ NetworkClient::NetworkClient(const std::shared_ptr<uvw::tcp_handle>& socket)
 
   _socket->on<uvw::data_event>(
       [this, alive = _alive](const uvw::data_event& event, uvw::tcp_handle&) {
-        if (!*alive) {
+        if (!*alive || _disconnected) {
           return;
         }
         HandleData(event.data, event.length);
@@ -73,7 +74,18 @@ NetworkClient::NetworkClient(const std::shared_ptr<uvw::tcp_handle>& socket)
   _socket->read();
 }
 
-NetworkClient::~NetworkClient() { Shutdown(); }
+NetworkClient::~NetworkClient() {
+  NetworkClient::Shutdown();
+  // Force-close even if a write was in flight; we're being destroyed,
+  // graceful flush is no longer relevant. The pending write callback
+  // will still fire asynchronously but *_alive = false makes it no-op.
+  if (!_socketClosed) {
+    _socket->close();
+    _socketClosed = true;
+  }
+  // Flip alive last so any late-firing uvw event after the dtor no-ops.
+  *_alive = false;
+}
 
 /**
  * Returns whether or not this client is in a disconnected state.
@@ -102,18 +114,17 @@ void NetworkClient::Shutdown() {
     return;
   }
 
-  // Mark dead before the async close so any late-firing uvw event
-  // short-circuits on the captured _alive flag.
-  *_alive = false;
   _disconnected = true;
 
   // Abandon anything queued; we're not going to flush it.
   _writeQueue.clear();
   _queuedBytes = 0;
 
+  // Defer close to the write_event callback if a uv_write is in flight —
+  // *_alive stays true so the callback can still see _disconnected and
+  // run the close path. (The dtor force-closes if we're still pending.)
   if (!_isWriting && !_socketClosed) {
     _socket->close();
-
     _socketClosed = true;
   }
 }
@@ -185,6 +196,14 @@ void NetworkClient::ProcessBuffer() {
  */
 void NetworkClient::SendDatagram(const std::shared_ptr<Datagram>& dg) {
   if (_socket == nullptr || _disconnected) {
+    return;
+  }
+
+  // Framing prefix is uint16; larger payloads would wrap and desync the peer.
+  if (dg->Size() > std::numeric_limits<uint16_t>::max()) {
+    spdlog::get("md")->error(
+        "Network client refusing oversized datagram ({}B > {}B max)",
+        dg->Size(), std::numeric_limits<uint16_t>::max());
     return;
   }
 

--- a/src/net/network_client.cpp
+++ b/src/net/network_client.cpp
@@ -1,5 +1,7 @@
 #include "network_client.h"
 
+#include <spdlog/spdlog.h>
+
 #include <cstring>
 
 namespace Ardos {
@@ -177,18 +179,9 @@ void NetworkClient::ProcessBuffer() {
 }
 
 /**
- * Sends a datagram to this network client.
- *
- * Buffers go onto an application-level FIFO and are issued one in-flight
- * uv_write at a time. This is the libuv-recommended backpressure pattern:
- * a slow peer that lets bytes accumulate in our queue past kHighWaterBytes
- * gets force-disconnected rather than allowing libuv's internal uv_write_t
- * queue to grow without bound and starve the loop's read side. The latter
- * is what wedged the whole daemon at pop=4096 — an MD participant whose
- * recv buffer was full made every Send pile uv_write requests until libuv
- * stopped servicing reads on the same fd.
- *
- * @param dg
+ * Sends a datagram to this network client. Buffers go onto an application-
+ * level FIFO drained one uv_write at a time; a peer that lets the queue
+ * exceed kHighWaterBytes is force-disconnected.
  */
 void NetworkClient::SendDatagram(const std::shared_ptr<Datagram>& dg) {
   if (_socket == nullptr || _disconnected) {
@@ -198,8 +191,9 @@ void NetworkClient::SendDatagram(const std::shared_ptr<Datagram>& dg) {
   const size_t sendSize = sizeof(uint16_t) + dg->Size();
 
   if (_queuedBytes + sendSize > kHighWaterBytes) {
-    // Bytes can't drain to this peer faster than they're produced. Cut
-    // them loose to protect the rest of the cluster from the slow reader.
+    spdlog::get("md")->warn(
+        "Network client {}:{} exceeded {}B write backlog; disconnecting",
+        _remoteAddress.ip, _remoteAddress.port, kHighWaterBytes);
     Shutdown();
     return;
   }

--- a/src/net/network_client.cpp
+++ b/src/net/network_client.cpp
@@ -53,11 +53,19 @@ NetworkClient::NetworkClient(const std::shared_ptr<uvw::tcp_handle>& socket)
         if (!*alive) {
           return;
         }
-        if (_disconnected && !_socketClosed) {
-          _socket->close();
-          _socketClosed = true;
-        }
         _isWriting = false;
+        if (_disconnected) {
+          // Drop anything still queued — the peer is going away. Close once
+          // the in-flight uv_write has resolved (this callback).
+          _writeQueue.clear();
+          _queuedBytes = 0;
+          if (!_socketClosed) {
+            _socket->close();
+            _socketClosed = true;
+          }
+          return;
+        }
+        PumpWrite();
       });
 
   _socket->read();
@@ -96,6 +104,10 @@ void NetworkClient::Shutdown() {
   // short-circuits on the captured _alive flag.
   *_alive = false;
   _disconnected = true;
+
+  // Abandon anything queued; we're not going to flush it.
+  _writeQueue.clear();
+  _queuedBytes = 0;
 
   if (!_isWriting && !_socketClosed) {
     _socket->close();
@@ -166,28 +178,55 @@ void NetworkClient::ProcessBuffer() {
 
 /**
  * Sends a datagram to this network client.
+ *
+ * Buffers go onto an application-level FIFO and are issued one in-flight
+ * uv_write at a time. This is the libuv-recommended backpressure pattern:
+ * a slow peer that lets bytes accumulate in our queue past kHighWaterBytes
+ * gets force-disconnected rather than allowing libuv's internal uv_write_t
+ * queue to grow without bound and starve the loop's read side. The latter
+ * is what wedged the whole daemon at pop=4096 — an MD participant whose
+ * recv buffer was full made every Send pile uv_write requests until libuv
+ * stopped servicing reads on the same fd.
+ *
  * @param dg
  */
 void NetworkClient::SendDatagram(const std::shared_ptr<Datagram>& dg) {
-  if (_socket == nullptr) {
+  if (_socket == nullptr || _disconnected) {
     return;
   }
 
   const size_t sendSize = sizeof(uint16_t) + dg->Size();
+
+  if (_queuedBytes + sendSize > kHighWaterBytes) {
+    // Bytes can't drain to this peer faster than they're produced. Cut
+    // them loose to protect the rest of the cluster from the slow reader.
+    Shutdown();
+    return;
+  }
+
   // runtime-sized buffer for uvw write:
   // NOLINTNEXTLINE(modernize-avoid-c-arrays)
   auto sendBuffer = std::unique_ptr<char[]>(new char[sendSize]);
-
   const uint16_t dgSize = dg->Size();
-
   auto* const sendPtr = &sendBuffer.get()[0];
-  // Datagram size tag.
   memcpy(sendPtr, &dgSize, sizeof(uint16_t));
-  // Datagram data.
   memcpy(sendPtr + sizeof(uint16_t), dg->GetData(), dg->Size());
 
+  _writeQueue.push_back({std::move(sendBuffer), sendSize});
+  _queuedBytes += sendSize;
+
+  PumpWrite();
+}
+
+void NetworkClient::PumpWrite() {
+  if (_isWriting || _writeQueue.empty() || _socketClosed) {
+    return;
+  }
+  auto front = std::move(_writeQueue.front());
+  _writeQueue.pop_front();
+  _queuedBytes -= front.size;
   _isWriting = true;
-  _socket->write(std::move(sendBuffer), sendSize);
+  _socket->write(std::move(front.buf), front.size);
 }
 
 }  // namespace Ardos

--- a/src/net/network_client.h
+++ b/src/net/network_client.h
@@ -1,6 +1,7 @@
 #ifndef ARDOS_NETWORK_CLIENT_H
 #define ARDOS_NETWORK_CLIENT_H
 
+#include <deque>
 #include <memory>
 #include <uvw.hpp>
 
@@ -20,7 +21,10 @@ class NetworkClient {
 
   [[nodiscard]] bool Disconnected() const;
 
-  void Shutdown();
+  // Virtual so subclasses (e.g. MDParticipant) get their full teardown
+  // path even when Shutdown is reached from inside NetworkClient itself
+  // — most notably the high-water-mark drop in SendDatagram below.
+  virtual void Shutdown();
 
   virtual void HandleDisconnect(uv_errno_t code) = 0;
   virtual void HandleClientDatagram(const std::shared_ptr<Datagram>& dg) = 0;
@@ -33,11 +37,26 @@ class NetworkClient {
   // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> from uvw read
   void HandleData(const std::unique_ptr<char[]>& data, size_t size);
   void ProcessBuffer();
+  // Drains one pending buffer onto the wire if no write is in flight. Called
+  // from SendDatagram and from the write_event callback.
+  void PumpWrite();
 
   std::shared_ptr<uvw::tcp_handle> _socket;
   uvw::socket_address _remoteAddress;
   uvw::socket_address _localAddress;
   std::vector<uint8_t> _data_buf;
+
+  // Application-level write queue. Bounded by kHighWaterBytes — a slow
+  // peer that lets bytes accumulate past the threshold gets disconnected
+  // rather than wedging the loop with an unbounded uv_write_t backlog.
+  struct PendingWrite {
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> for uvw
+    std::unique_ptr<char[]> buf;
+    size_t size;
+  };
+  std::deque<PendingWrite> _writeQueue;
+  size_t _queuedBytes = 0;
+  static constexpr size_t kHighWaterBytes = 4 * 1024 * 1024;  // 4 MiB
 
   bool _isWriting = false;
   bool _socketClosed = false;

--- a/src/net/network_client.h
+++ b/src/net/network_client.h
@@ -21,9 +21,8 @@ class NetworkClient {
 
   [[nodiscard]] bool Disconnected() const;
 
-  // Virtual so subclasses (e.g. MDParticipant) get their full teardown
-  // path even when Shutdown is reached from inside NetworkClient itself
-  // — most notably the high-water-mark drop in SendDatagram below.
+  // Virtual so the high-water drop in SendDatagram dispatches to subclass
+  // teardown (channel unsubscribes, post-removes, etc).
   virtual void Shutdown();
 
   virtual void HandleDisconnect(uv_errno_t code) = 0;
@@ -37,8 +36,7 @@ class NetworkClient {
   // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> from uvw read
   void HandleData(const std::unique_ptr<char[]>& data, size_t size);
   void ProcessBuffer();
-  // Drains one pending buffer onto the wire if no write is in flight. Called
-  // from SendDatagram and from the write_event callback.
+  // Issues the next queued write, if any, when no write is in flight.
   void PumpWrite();
 
   std::shared_ptr<uvw::tcp_handle> _socket;
@@ -46,9 +44,7 @@ class NetworkClient {
   uvw::socket_address _localAddress;
   std::vector<uint8_t> _data_buf;
 
-  // Application-level write queue. Bounded by kHighWaterBytes — a slow
-  // peer that lets bytes accumulate past the threshold gets disconnected
-  // rather than wedging the loop with an unbounded uv_write_t backlog.
+  // Application-level write queue bounded by kHighWaterBytes.
   struct PendingWrite {
     // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> for uvw
     std::unique_ptr<char[]> buf;

--- a/src/net/network_client.h
+++ b/src/net/network_client.h
@@ -52,7 +52,7 @@ class NetworkClient {
   };
   std::deque<PendingWrite> _writeQueue;
   size_t _queuedBytes = 0;
-  static constexpr size_t kHighWaterBytes = 4 * 1024 * 1024;  // 4 MiB
+  static constexpr size_t kHighWaterBytes = size_t{4} * 1024 * 1024;  // 4 MiB
 
   bool _isWriting = false;
   bool _socketClosed = false;

--- a/src/net/tcp_transport.cpp
+++ b/src/net/tcp_transport.cpp
@@ -50,7 +50,7 @@ TcpTransportConnection::TcpTransportConnection(
 
   _socket->on<uvw::data_event>(
       [this, alive = _alive](const uvw::data_event& event, uvw::tcp_handle&) {
-        if (!*alive) {
+        if (!*alive || _closed) {
           return;
         }
         HandleData(event.data, event.length);
@@ -80,6 +80,12 @@ TcpTransportConnection::TcpTransportConnection(
 
 TcpTransportConnection::~TcpTransportConnection() {
   Close();
+  // Force-close even if a write was in flight; the pending write callback
+  // will fire async but *_alive = false makes it no-op.
+  if (!_socketClosed) {
+    _socket->close();
+    _socketClosed = true;
+  }
   *_alive = false;
 }
 

--- a/src/net/tcp_transport.cpp
+++ b/src/net/tcp_transport.cpp
@@ -61,11 +61,18 @@ TcpTransportConnection::TcpTransportConnection(
         if (!*alive) {
           return;
         }
-        if (_closed && !_socketClosed) {
-          _socket->close();
-          _socketClosed = true;
-        }
         _isWriting = false;
+        if (_closed) {
+          // Drop anything still queued — the connection is going away.
+          _writeQueue.clear();
+          _queuedBytes = 0;
+          if (!_socketClosed) {
+            _socket->close();
+            _socketClosed = true;
+          }
+          return;
+        }
+        PumpWrite();
       });
 
   _socket->read();
@@ -96,15 +103,36 @@ void TcpTransportConnection::Send(const uint8_t* data, size_t len,
   }
 
   const size_t sendSize = sizeof(uint16_t) + len;
+
+  if (_queuedBytes + sendSize > kHighWaterBytes) {
+    spdlog::get("ca")->warn(
+        "TCP transport: client {}:{} exceeded {}B write backlog; disconnecting",
+        _remoteEndpoint.ip, _remoteEndpoint.port, kHighWaterBytes);
+    Close();
+    return;
+  }
+
   // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> for uvw write
   auto sendBuffer = std::unique_ptr<char[]>(new char[sendSize]);
-
   const auto dgSize = static_cast<uint16_t>(len);
   std::memcpy(sendBuffer.get(), &dgSize, sizeof(uint16_t));
   std::memcpy(sendBuffer.get() + sizeof(uint16_t), data, len);
 
+  _writeQueue.push_back({std::move(sendBuffer), sendSize});
+  _queuedBytes += sendSize;
+
+  PumpWrite();
+}
+
+void TcpTransportConnection::PumpWrite() {
+  if (_isWriting || _writeQueue.empty() || _socketClosed) {
+    return;
+  }
+  auto front = std::move(_writeQueue.front());
+  _writeQueue.pop_front();
+  _queuedBytes -= front.size;
   _isWriting = true;
-  _socket->write(std::move(sendBuffer), sendSize);
+  _socket->write(std::move(front.buf), front.size);
 }
 
 void TcpTransportConnection::Close() {
@@ -112,6 +140,10 @@ void TcpTransportConnection::Close() {
     return;
   }
   _closed = true;
+
+  // Abandon anything queued; we're not going to flush it.
+  _writeQueue.clear();
+  _queuedBytes = 0;
 
   // *_alive flips false only in the destructor; an in-flight write still
   // needs the write_event lambda to run and close the socket.

--- a/src/net/tcp_transport.h
+++ b/src/net/tcp_transport.h
@@ -50,7 +50,7 @@ class TcpTransportConnection final : public ITransportConnection {
   };
   std::deque<PendingWrite> _writeQueue;
   size_t _queuedBytes = 0;
-  static constexpr size_t kHighWaterBytes = 4 * 1024 * 1024;  // 4 MiB
+  static constexpr size_t kHighWaterBytes = size_t{4} * 1024 * 1024;  // 4 MiB
 
   bool _closed = false;
   bool _isWriting = false;

--- a/src/net/tcp_transport.h
+++ b/src/net/tcp_transport.h
@@ -1,6 +1,7 @@
 #ifndef ARDOS_TCP_TRANSPORT_H
 #define ARDOS_TCP_TRANSPORT_H
 
+#include <deque>
 #include <memory>
 #include <string>
 #include <uvw.hpp>
@@ -30,6 +31,8 @@ class TcpTransportConnection final : public ITransportConnection {
   void HandleData(const std::unique_ptr<char[]>& data, size_t size);
   void ProcessBuffer();
   void DeliverMessage(const uint8_t* data, size_t len);
+  // Issues the next queued write, if any, when no write is in flight.
+  void PumpWrite();
 
   std::shared_ptr<uvw::tcp_handle> _socket;
   std::weak_ptr<ITransportHandler> _handler;
@@ -38,6 +41,16 @@ class TcpTransportConnection final : public ITransportConnection {
 
   // Accumulator for partial datagrams across uvw data_events.
   std::vector<uint8_t> _readBuffer;
+
+  // Application-level write queue bounded by kHighWaterBytes.
+  struct PendingWrite {
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays): unique_ptr<char[]> for uvw
+    std::unique_ptr<char[]> buf;
+    size_t size;
+  };
+  std::deque<PendingWrite> _writeQueue;
+  size_t _queuedBytes = 0;
+  static constexpr size_t kHighWaterBytes = 4 * 1024 * 1024;  // 4 MiB
 
   bool _closed = false;
   bool _isWriting = false;

--- a/tests/benchmarks/test_bench_ca.py
+++ b/tests/benchmarks/test_bench_ca.py
@@ -59,17 +59,15 @@ from tests.common.msgtypes import (
 
 pytestmark = pytest.mark.benchmark(group="ca")
 
-POPULATION_SIZES = [256, 1024]
+POPULATION_SIZES = [256, 1024, 4096]
 # Operations per step. Held constant so per-step time scales primarily with
 # population.
 ACTIVE = 4
-# pop=4096 and pop=10000 were attempted but the daemon stalls part-way through
-# the second timed-step iteration: iter-1 broadcasts complete end-to-end, but
-# at some point libuv stops processing AI messages and no further broadcasts
-# go out. The CA throughput indexes are fine -- iter 1 confirms routing
-# delivers to all 4096 subscribers. The hang is somewhere in the
-# uvw/AMQP-CPP/event-loop interaction at high N. Bump this back up once the
-# stall is diagnosed.
+# pop=4096 currently stalls part-way through the second timed-step iteration:
+# iter-1 broadcasts complete end-to-end, but at some point libuv stops
+# processing AI messages and no further broadcasts go out. Diagnosis runs
+# under the bench_monitor fixture (ARDOS_BENCH_MONITOR=1) which samples
+# broker/proc/socket state on a fixed interval.
 
 CLIENT_CHANNEL_BASE = 1_000_000_000
 
@@ -201,7 +199,7 @@ def _send_set_location(ai: AIConnection, do_id: int, parent: int, zone: int) -> 
 
 
 @pytest.fixture(params=POPULATION_SIZES, ids=lambda n: f"pop={n}")
-def populated_cluster(request, ardos, ai_conn, client_conn):
+def populated_cluster(request, ardos, ai_conn, client_conn, bench_monitor):
     """MD+SS+CA with ``request.param`` connected, authed, interested clients.
 
     Interest covers TEST_ZONE and ALT_ZONE so the location benchmark can
@@ -209,7 +207,7 @@ def populated_cluster(request, ardos, ai_conn, client_conn):
     """
     n_pop = request.param
 
-    ardos(
+    daemon = ardos(
         md=True,
         ss=True,
         ca=True,
@@ -234,6 +232,12 @@ def populated_cluster(request, ardos, ai_conn, client_conn):
         },
     )
 
+    # Start the diagnostic monitor against the daemon. No-op unless
+    # ARDOS_BENCH_MONITOR=1.
+    if daemon.pid is not None:
+        bench_monitor.start(daemon.pid)
+    bench_monitor.mark("setup_start", n_pop=n_pop)
+
     ai = ai_conn()
 
     # Connect + hello every client. Sequential because CA allocates channels
@@ -244,6 +248,7 @@ def populated_cluster(request, ardos, ai_conn, client_conn):
         c.hello(dc_hash("test.dc"), "dev")
         c.expect_hello_resp()
         clients.append(c)
+    bench_monitor.mark("setup_clients_connected", n_pop=n_pop)
 
     # Pipeline SET_STATE + two ADD_INTEREST (TEST_ZONE and ALT_ZONE) for every
     # client. Per-channel FIFO guarantees SET_STATE lands before ADD_INTEREST.
@@ -252,6 +257,7 @@ def populated_cluster(request, ardos, ai_conn, client_conn):
         ai.set_client_state(ch, AUTH_STATE_ESTABLISHED, wait=False)
         ai.add_interest(ch, interest_id=1, parent=TEST_PARENT, zone=TEST_ZONE)
         ai.add_interest(ch, interest_id=2, parent=TEST_PARENT, zone=ALT_ZONE)
+    bench_monitor.mark("setup_interests_sent", n_pop=n_pop)
 
     # Wait until every client has seen two DONE_INTEREST_RESP. That confirms
     # both ADD_INTERESTs (and therefore the prior SET_STATE) have committed.
@@ -261,6 +267,7 @@ def populated_cluster(request, ardos, ai_conn, client_conn):
         accept_msgs={CLIENT_DONE_INTEREST_RESP},
         timeout=max(60.0, n_pop * 0.02),
     )
+    bench_monitor.mark("setup_done", n_pop=n_pop)
 
     return ai, clients
 
@@ -270,7 +277,7 @@ def populated_cluster(request, ardos, ai_conn, client_conn):
 # ---------------------------------------------------------------------------
 
 
-def test_object_churn_throughput(populated_cluster, benchmark):
+def test_object_churn_throughput(populated_cluster, benchmark, bench_monitor):
     """AI creates ACTIVE objects in TEST_ZONE, then deletes them. Each client
     must observe ACTIVE entry messages and ACTIVE leave messages.
     """
@@ -278,8 +285,12 @@ def test_object_churn_throughput(populated_cluster, benchmark):
     dclass = class_id("test.dc", "DistributedTestObject1")
     required = _required_payload()
     counter = [CHURN_DOID_BASE]
+    iter_idx = [0]
 
     def step():
+        i = iter_idx[0]
+        iter_idx[0] += 1
+        bench_monitor.mark("churn_iter_start", iter=i)
         base = counter[0]
         counter[0] += ACTIVE
         for k in range(ACTIVE):
@@ -290,25 +301,29 @@ def test_object_churn_throughput(populated_cluster, benchmark):
                 dclass_id=dclass,
                 required=required,
             )
+        bench_monitor.mark("churn_creates_sent", iter=i)
         _await_counts(
             clients,
             per_client=ACTIVE,
             accept_msgs=ENTRY_MSGS,
             timeout=60.0,
         )
+        bench_monitor.mark("churn_creates_drained", iter=i)
         for k in range(ACTIVE):
             ai.delete_object(base + k)
+        bench_monitor.mark("churn_deletes_sent", iter=i)
         _await_counts(
             clients,
             per_client=ACTIVE,
             accept_msgs={CLIENT_OBJECT_LEAVING},
             timeout=60.0,
         )
+        bench_monitor.mark("churn_iter_done", iter=i)
 
     benchmark(step)
 
 
-def test_field_update_throughput(populated_cluster, benchmark):
+def test_field_update_throughput(populated_cluster, benchmark, bench_monitor):
     """AI fires ACTIVE field updates on pre-existing objects in TEST_ZONE.
     Every client (interest in TEST_ZONE) must see ACTIVE CLIENT_OBJECT_SET_FIELD.
 
@@ -335,23 +350,30 @@ def test_field_update_throughput(populated_cluster, benchmark):
         accept_msgs=ENTRY_MSGS,
         timeout=60.0,
     )
+    bench_monitor.mark("field_precreate_done")
 
     payload = Datagram().add_string("u").bytes()
+    iter_idx = [0]
 
     def step():
+        i = iter_idx[0]
+        iter_idx[0] += 1
+        bench_monitor.mark("field_iter_start", iter=i)
         for k in range(ACTIVE):
             ai.set_field(FIELD_DOID_BASE + k, fid, payload)
+        bench_monitor.mark("field_updates_sent", iter=i)
         _await_counts(
             clients,
             per_client=ACTIVE,
             accept_msgs={CLIENT_OBJECT_SET_FIELD},
             timeout=60.0,
         )
+        bench_monitor.mark("field_iter_done", iter=i)
 
     benchmark(step)
 
 
-def test_location_switch_throughput(populated_cluster, benchmark):
+def test_location_switch_throughput(populated_cluster, benchmark, bench_monitor):
     """AI relocates ACTIVE pre-existing objects between TEST_ZONE and
     ALT_ZONE. Each client (interested in both zones) sees ACTIVE
     CLIENT_OBJECT_LOCATION updates per step.
@@ -374,19 +396,26 @@ def test_location_switch_throughput(populated_cluster, benchmark):
         accept_msgs=ENTRY_MSGS,
         timeout=60.0,
     )
+    bench_monitor.mark("location_precreate_done")
 
     state = {"zone": TEST_ZONE}
+    iter_idx = [0]
 
     def step():
+        i = iter_idx[0]
+        iter_idx[0] += 1
+        bench_monitor.mark("location_iter_start", iter=i, from_zone=state["zone"])
         target = ALT_ZONE if state["zone"] == TEST_ZONE else TEST_ZONE
         for k in range(ACTIVE):
             _send_set_location(ai, LOC_DOID_BASE + k, TEST_PARENT, target)
         state["zone"] = target
+        bench_monitor.mark("location_sends_done", iter=i, to_zone=target)
         _await_counts(
             clients,
             per_client=ACTIVE,
             accept_msgs={CLIENT_OBJECT_LOCATION},
             timeout=60.0,
         )
+        bench_monitor.mark("location_iter_done", iter=i)
 
     benchmark(step)

--- a/tests/benchmarks/test_bench_ca.py
+++ b/tests/benchmarks/test_bench_ca.py
@@ -63,11 +63,6 @@ POPULATION_SIZES = [256, 1024, 4096]
 # Operations per step. Held constant so per-step time scales primarily with
 # population.
 ACTIVE = 4
-# pop=4096 currently stalls part-way through the second timed-step iteration:
-# iter-1 broadcasts complete end-to-end, but at some point libuv stops
-# processing AI messages and no further broadcasts go out. Diagnosis runs
-# under the bench_monitor fixture (ARDOS_BENCH_MONITOR=1) which samples
-# broker/proc/socket state on a fixed interval.
 
 CLIENT_CHANNEL_BASE = 1_000_000_000
 

--- a/tests/benchmarks/test_bench_ca.py
+++ b/tests/benchmarks/test_bench_ca.py
@@ -240,6 +240,15 @@ def populated_cluster(request, ardos, ai_conn, client_conn, bench_monitor):
 
     ai = ai_conn()
 
+    # Create the root DistributedDirectory at TEST_PARENT before any
+    # ADD_INTEREST fires.
+    ai.create_object(
+        do_id=TEST_PARENT,
+        parent=0,
+        zone=0,
+        dclass_id=class_id("test.dc", "DistributedDirectory"),
+    )
+
     # Connect + hello every client. Sequential because CA allocates channels
     # in connect order — client[i] gets CLIENT_CHANNEL_BASE + i.
     clients: List[ClientConnection] = []

--- a/tests/common/ardos.py
+++ b/tests/common/ardos.py
@@ -1128,6 +1128,10 @@ class Daemon:
         except OSError:
             pass
 
+    @property
+    def pid(self) -> Optional[int]:
+        return self._proc.pid if self._proc else None
+
     def stop(self) -> None:
         if not self._proc:
             return

--- a/tests/common/monitor.py
+++ b/tests/common/monitor.py
@@ -1,0 +1,126 @@
+"""Test-side handle for the background sampler in tests.tools.monitor.
+
+Spawns the sampler as a subprocess against a Daemon's PID, and provides
+`mark()` for the test to drop phase markers into a sibling JSONL. Use
+via the `bench_monitor` fixture; this module exists so the bench files
+don't have to know about subprocess plumbing.
+
+Both files use ``time.time_ns()`` so post-hoc analysis can merge them by
+timestamp without per-process clock offsets.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+
+class BenchMonitor:
+    """Lifetime: created in a fixture, started once the daemon PID is known,
+    stopped on fixture teardown. ``mark()`` is cheap enough to call from
+    inside a benchmark step (single line append + optional flush)."""
+
+    def __init__(
+        self,
+        out_dir: Path,
+        *,
+        enabled: bool = True,
+        rabbit_host: str = "127.0.0.1",
+        rabbit_user: str = "guest",
+        rabbit_pass: str = "guest",
+        amqp_port: int = 5672,
+        interval: float = 0.5,
+    ) -> None:
+        self.out_dir = Path(out_dir)
+        self.enabled = enabled
+        self.rabbit_host = rabbit_host
+        self.rabbit_user = rabbit_user
+        self.rabbit_pass = rabbit_pass
+        self.amqp_port = amqp_port
+        self.interval = interval
+        self._proc: Optional[subprocess.Popen] = None
+        self._marks: Optional[Any] = None
+        self.data_path = self.out_dir / "monitor-data.jsonl"
+        self.marks_path = self.out_dir / "monitor-marks.jsonl"
+
+    # ------------------------------------------------------------------ start
+
+    def start(self, daemon_pid: int) -> None:
+        if not self.enabled or self._proc is not None:
+            return
+        self.out_dir.mkdir(parents=True, exist_ok=True)
+        self._marks = open(self.marks_path, "w", buffering=1)
+        self._write_mark("monitor_started", pid=daemon_pid)
+
+        # Run the sampler as a module so its imports resolve from the repo.
+        env = os.environ.copy()
+        env["PYTHONUNBUFFERED"] = "1"
+        self._proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-m",
+                "tests.tools.monitor",
+                "--pid",
+                str(daemon_pid),
+                "--out",
+                str(self.data_path),
+                "--interval",
+                str(self.interval),
+                "--rabbit-host",
+                self.rabbit_host,
+                "--rabbit-user",
+                self.rabbit_user,
+                "--rabbit-pass",
+                self.rabbit_pass,
+                "--amqp-port",
+                str(self.amqp_port),
+            ],
+            env=env,
+            # Inherit stderr so any sampler crash is visible in CI logs.
+            stdout=subprocess.DEVNULL,
+        )
+
+    # ------------------------------------------------------------------ mark
+
+    def mark(self, event: str, **fields: Any) -> None:
+        """Drop a phase marker into the marks JSONL. Safe to call before
+        ``start()`` (no-op) and after ``stop()`` (no-op)."""
+        if not self.enabled or self._marks is None:
+            return
+        self._write_mark(event, **fields)
+
+    def _write_mark(self, event: str, **fields: Any) -> None:
+        rec = {"t_ns": time.time_ns(), "src": "phase", "event": event}
+        rec.update(fields)
+        try:
+            self._marks.write(json.dumps(rec, separators=(",", ":")))
+            self._marks.write("\n")
+        except (OSError, ValueError):
+            pass
+
+    # ------------------------------------------------------------------ stop
+
+    def stop(self) -> None:
+        if self._marks is not None:
+            self._write_mark("monitor_stopping")
+            try:
+                self._marks.close()
+            except OSError:
+                pass
+            self._marks = None
+        if self._proc is None:
+            return
+        if self._proc.poll() is None:
+            self._proc.send_signal(signal.SIGTERM)
+            try:
+                self._proc.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait(timeout=2.0)
+        self._proc = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from tests.common.ardos import (
     Daemon,
     MDConnection,
 )
+from tests.common.monitor import BenchMonitor
 from tests.common.msg_coverage import tracker
 
 LOG_DIR = Path(__file__).resolve().parent / "logs"
@@ -194,6 +195,42 @@ def ardos(tmp_path: Path, request) -> Iterator[Callable[..., Daemon]]:
                 d.log_path.unlink(missing_ok=True)
             except OSError:
                 pass
+
+
+# ---------------------------------------------------------------------------
+# Bench monitor — opt-in via ARDOS_BENCH_MONITOR=1
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def bench_monitor(request) -> Iterator[BenchMonitor]:
+    """Background sampler for benchmark runs. On by default; set
+    ``ARDOS_BENCH_MONITOR=0`` to disable (e.g. when the ~1% CPU overhead
+    of the sampler would skew a sensitive measurement). Output lives at
+    ``tests/logs/monitor/<test-id>/`` and ships with the daemon-logs
+    artifact.
+
+    The fixture is always provided (even when disabled) so callers can
+    unconditionally invoke ``.mark()`` and ``.start()``; both no-op when
+    the monitor is off.
+    """
+    enabled = os.environ.get("ARDOS_BENCH_MONITOR", "1") == "1"
+    # nodeid embeds parametrisation (pop=4096, etc); sanitise for filesystem
+    safe_id = (
+        request.node.nodeid.replace("/", "_").replace("::", "__").replace(" ", "_")
+    )
+    out_dir = LOG_DIR / "monitor" / safe_id
+    mon = BenchMonitor(
+        out_dir,
+        enabled=enabled,
+        rabbit_host=cfg.RABBITMQ_HOST,
+        rabbit_user=cfg.RABBITMQ_USER,
+        rabbit_pass=cfg.RABBITMQ_PASS,
+        amqp_port=cfg.RABBITMQ_PORT,
+        interval=float(os.environ.get("ARDOS_BENCH_MONITOR_INTERVAL", "0.5")),
+    )
+    yield mon
+    mon.stop()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,7 +207,7 @@ def bench_monitor(request) -> Iterator[BenchMonitor]:
     the monitor is off.
     """
     enabled = os.environ.get("ARDOS_BENCH_MONITOR", "1") == "1"
-    # nodeid embeds parametrisation (pop=4096, etc); sanitise for filesystem
+    # nodeid embeds parametrisation; sanitise for filesystem
     safe_id = (
         request.node.nodeid.replace("/", "_").replace("::", "__").replace(" ", "_")
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -185,16 +185,8 @@ def ardos(tmp_path: Path, request) -> Iterator[Callable[..., Daemon]]:
 
     yield _factory
 
-    failed = hasattr(request.node, "rep_call") and request.node.rep_call.failed
     for d in started:
         d.stop()
-    # On failure, keep the logs; on success, drop them to avoid clutter.
-    if not failed:
-        for d in started:
-            try:
-                d.log_path.unlink(missing_ok=True)
-            except OSError:
-                pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/files/test.dc
+++ b/tests/files/test.dc
@@ -2,6 +2,12 @@
 // Kept minimal but exercises every field kind/keyword pair we assert on
 // in tests.
 
+// Root directory object. Tests instantiate one at a well-known DoId
+// (typically 1) so it can act as the parent of child objects and respond
+// to STATESERVER_OBJECT_GET_ZONES_OBJECTS queries on their behalf.
+dclass DistributedDirectory {
+};
+
 dclass DistributedTestObject1 {
 	setRequired1(uint32 r = 78) required broadcast ram;
 	setB1(uint8 x) broadcast;

--- a/tests/tools/monitor.py
+++ b/tests/tools/monitor.py
@@ -30,6 +30,10 @@ Sources:
   - "rmq_overview": cluster-wide message rates + memory + alarms
   - "amqp_sock" : ss output for the daemon's connection to the broker
   - "sys"       : /proc/loadavg, /proc/meminfo MemAvailable, steal %
+  - "thread"    : per-thread wchan + kernel stack (where the daemon is parked)
+  - "daemon_sock": per-port aggregate Send-Q/Recv-Q across all daemon-owned
+                    TCP sockets, bucketed by daemon-side port (6667 CA accepts,
+                    7100 MD accepts, 5672 outbound to broker, "other")
   - "error"     : sampler-side errors (so a missing tool doesn't kill the run)
 """
 
@@ -215,6 +219,132 @@ def _sample_amqp_socket(out, amqp_port: int) -> None:
         _emit(out, "error", source="amqp_sock", err=str(e))
 
 
+def _sample_thread_stacks(out, pid: int) -> None:
+    """Per-thread kernel stack + wchan. Tells us conclusively whether the
+    libuv loop is parked in epoll_wait (idle), futex_wait (lock contention),
+    tcp_sendmsg (write backpressure), or something else.
+
+    /proc/PID/task/TID/stack requires CAP_SYS_PTRACE or
+    kernel.yama.ptrace_scope=0 on Ubuntu. wchan is unrestricted and always
+    available — fall back to that when stack is denied.
+    """
+    try:
+        tids = os.listdir(f"/proc/{pid}/task")
+    except FileNotFoundError:
+        global _running
+        _running = False
+        return
+    except OSError as e:
+        _emit(out, "error", source="thread", err=str(e))
+        return
+
+    for tid in tids:
+        base = f"/proc/{pid}/task/{tid}"
+        try:
+            with open(f"{base}/comm") as f:
+                comm = f.read().strip()
+            with open(f"{base}/wchan") as f:
+                wchan = f.read().strip()
+        except (FileNotFoundError, OSError):
+            continue  # thread exited mid-sample, skip
+        stack: Optional[str] = None
+        try:
+            with open(f"{base}/stack") as f:
+                stack = f.read().strip()
+        except (FileNotFoundError, PermissionError, OSError):
+            pass  # ptrace_scope restriction — wchan still useful
+        fields: Dict[str, Any] = {"tid": int(tid), "comm": comm, "wchan": wchan}
+        if stack:
+            # Cap stack size: typical kernel stacks are <2KB but pathological
+            # cases can blow up the log. Truncate to first 32 frames.
+            lines = stack.splitlines()[:32]
+            fields["stack"] = "\n".join(lines)
+        _emit(out, "thread", **fields)
+
+
+def _sample_daemon_sockets(out, pid: int) -> None:
+    """All TCP sockets owned by the daemon, bucketed per daemon-side port.
+    Captures Send-Q/Recv-Q distribution so we can see:
+      - Are client TCP writes backed up (Send-Q on 6667 sockets)?
+      - Is the AI socket unread (Recv-Q on 7100 sockets)?
+      - Is the broker connection clear (5672 outbound)?
+    """
+    try:
+        r = subprocess.run(
+            ["ss", "-tnp"],
+            capture_output=True,
+            text=True,
+            timeout=3.0,
+        )
+        if r.returncode != 0:
+            _emit(out, "error", source="daemon_sock", err=r.stderr.strip()[:200])
+            return
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        _emit(out, "error", source="daemon_sock", err=str(e))
+        return
+
+    pid_marker = f"pid={pid},"
+    # bucket -> list of (recv_q, send_q)
+    buckets: Dict[str, List[tuple]] = {}
+    for line in r.stdout.splitlines()[1:]:
+        if pid_marker not in line:
+            continue
+        parts = line.split()
+        if len(parts) < 5:
+            continue
+        try:
+            rq, sq = int(parts[1]), int(parts[2])
+        except ValueError:
+            continue
+        local, peer = parts[3], parts[4]
+
+        def _port(ep: str) -> str:
+            return ep.rsplit(":", 1)[-1] if ":" in ep else ""
+
+        lport, pport = _port(local), _port(peer)
+        # Categorise by daemon-side role. Accepted listeners: local port is
+        # the daemon's listen port. Outbound: peer port is the broker.
+        if lport == "6667":
+            bucket = "ca_accept"  # daemon writing OBJECT_LEAVING etc. to client
+        elif lport == "7100":
+            bucket = "md_accept"  # AI socket lives here
+        elif pport == "5672":
+            bucket = "amqp_out"
+        elif lport == "5672":
+            bucket = "amqp_in"  # shouldn't happen but be defensive
+        else:
+            bucket = "other"
+        buckets.setdefault(bucket, []).append((rq, sq))
+
+    def _pct(arr: List[int], p: int) -> int:
+        if not arr:
+            return 0
+        s = sorted(arr)
+        i = min(len(s) - 1, (p * len(s)) // 100)
+        return s[i]
+
+    for bucket, samples in buckets.items():
+        recvs = [s[0] for s in samples]
+        sends = [s[1] for s in samples]
+        _emit(
+            out,
+            "daemon_sock",
+            bucket=bucket,
+            count=len(samples),
+            recv_total=sum(recvs),
+            recv_max=max(recvs) if recvs else 0,
+            recv_p50=_pct(recvs, 50),
+            recv_p99=_pct(recvs, 99),
+            send_total=sum(sends),
+            send_max=max(sends) if sends else 0,
+            send_p50=_pct(sends, 50),
+            send_p99=_pct(sends, 99),
+            # Count how many sockets have nonzero queues
+            recv_nonzero=sum(1 for v in recvs if v > 0),
+            send_nonzero=sum(1 for v in sends if v > 0),
+        )
+
+
 _LAST_CPU: Optional[List[int]] = None
 
 
@@ -293,12 +423,20 @@ def main(argv: Optional[List[str]] = None) -> int:
             rabbit_host=args.rabbit_host,
             amqp_port=args.amqp_port,
         )
+        # Heavier samplers (thread stacks, full ss) tick on every Nth interval
+        # to keep monitor overhead under ~1% CPU.
+        heavy_every = max(1, int(round(1.0 / args.interval)))  # ~1s cadence
+        tick = 0
         while _running:
             t0 = time.monotonic()
             _sample_proc(out, args.pid)
             _sample_rmq(out, args.rabbit_host, args.rabbit_user, args.rabbit_pass)
             _sample_amqp_socket(out, args.amqp_port)
             _sample_sys(out)
+            if tick % heavy_every == 0:
+                _sample_thread_stacks(out, args.pid)
+                _sample_daemon_sockets(out, args.pid)
+            tick += 1
             # Sleep the remainder of the interval. Pin to wall-clock cadence
             # rather than fixed sleep so a slow sample doesn't bias the
             # series.

--- a/tests/tools/monitor.py
+++ b/tests/tools/monitor.py
@@ -1,0 +1,317 @@
+"""Background system sampler for diagnostic benchmark runs.
+
+Spawned as a subprocess by the bench harness; samples broker, daemon
+process, and socket state on a fixed interval and writes one JSONL
+event per sample. Stops cleanly on SIGTERM.
+
+Output is consumed post-hoc to correlate broker flow-state / queue depth
+/ daemon RSS / AMQP socket Send-Q against phase markers emitted by the
+test harness into a sibling file.
+
+CLI:
+
+    python -m tests.tools.monitor \
+        --pid <daemon-pid> \
+        --out  <path/to/monitor-data.jsonl> \
+        --interval 0.5 \
+        --rabbit-host 127.0.0.1 \
+        --rabbit-user guest \
+        --rabbit-pass guest \
+        --amqp-port 5672
+
+Each output line is a JSON object:
+
+    {"t_ns": <int>, "src": "<source>", ...source-specific fields}
+
+Sources:
+  - "proc"      : daemon RSS, threads, ctx switches, utime/stime
+  - "rmq_conn"  : per-connection state (look for state=="flow")
+  - "rmq_queue" : per-queue messages/unacked/memory
+  - "rmq_overview": cluster-wide message rates + memory + alarms
+  - "amqp_sock" : ss output for the daemon's connection to the broker
+  - "sys"       : /proc/loadavg, /proc/meminfo MemAvailable, steal %
+  - "error"     : sampler-side errors (so a missing tool doesn't kill the run)
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_running = True
+
+
+def _stop(_signum, _frame) -> None:
+    global _running
+    _running = False
+
+
+def _now_ns() -> int:
+    # time.time_ns is wall-clock; comparable across processes (unlike
+    # monotonic_ns, whose reference point is per-process per Python docs).
+    return time.time_ns()
+
+
+def _emit(out, src: str, **fields: Any) -> None:
+    rec: Dict[str, Any] = {"t_ns": _now_ns(), "src": src}
+    rec.update(fields)
+    out.write(json.dumps(rec, separators=(",", ":")))
+    out.write("\n")
+
+
+# ---------------------------------------------------------------------------
+# Samplers
+# ---------------------------------------------------------------------------
+
+
+def _sample_proc(out, pid: int) -> None:
+    """Daemon process metrics from /proc."""
+    try:
+        with open(f"/proc/{pid}/status") as f:
+            status = {}
+            for line in f:
+                k, _, v = line.partition(":")
+                status[k.strip()] = v.strip()
+        with open(f"/proc/{pid}/stat") as f:
+            stat = f.read().split()
+        # /proc/[pid]/stat fields (1-indexed, see proc(5)):
+        # 14 utime, 15 stime, 22 starttime, 23 vsize, 24 rss (pages)
+        utime = int(stat[13])
+        stime = int(stat[14])
+        num_threads = int(stat[19])
+
+        def _kb(s: str) -> Optional[int]:
+            try:
+                return int(s.split()[0])
+            except (ValueError, IndexError):
+                return None
+
+        _emit(
+            out,
+            "proc",
+            pid=pid,
+            rss_kb=_kb(status.get("VmRSS", "")),
+            vm_kb=_kb(status.get("VmSize", "")),
+            threads=num_threads,
+            utime=utime,
+            stime=stime,
+            vol_ctxt=int(status.get("voluntary_ctxt_switches", 0) or 0),
+            invol_ctxt=int(status.get("nonvoluntary_ctxt_switches", 0) or 0),
+        )
+
+        # fd count — separate try because /proc/[pid]/fd needs perms
+        try:
+            fd_count = len(os.listdir(f"/proc/{pid}/fd"))
+            _emit(out, "proc_fd", pid=pid, fd_count=fd_count)
+        except OSError:
+            pass
+    except FileNotFoundError:
+        # Daemon process is gone — stop the loop.
+        global _running
+        _running = False
+    except (OSError, ValueError) as e:
+        _emit(out, "error", source="proc", err=str(e))
+
+
+def _rmq_get(
+    host: str, user: str, password: str, path: str, timeout: float = 0.8
+) -> Optional[object]:
+    auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+    req = urllib.request.Request(
+        f"http://{host}:15672/api/{path}",
+        headers={"Authorization": f"Basic {auth}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, OSError, ValueError):
+        return None
+
+
+def _sample_rmq(out, host: str, user: str, password: str) -> None:
+    """Broker connections, queues, overview."""
+    overview = _rmq_get(host, user, password, "overview")
+    if overview is not None and isinstance(overview, dict):
+        _emit(
+            out,
+            "rmq_overview",
+            object_totals=overview.get("object_totals"),
+            queue_totals=overview.get("queue_totals"),
+            message_stats=overview.get("message_stats"),
+            cluster_name=overview.get("cluster_name"),
+        )
+
+    conns = _rmq_get(host, user, password, "connections")
+    if isinstance(conns, list):
+        for c in conns:
+            _emit(
+                out,
+                "rmq_conn",
+                name=c.get("name"),
+                state=c.get("state"),
+                channels=c.get("channels"),
+                send_oct=c.get("send_oct"),
+                recv_oct=c.get("recv_oct"),
+                send_pend=c.get("send_pend"),
+                send_cnt=c.get("send_cnt"),
+                recv_cnt=c.get("recv_cnt"),
+                # send_oct_details.rate is the publish byte rate
+                send_oct_rate=(c.get("send_oct_details") or {}).get("rate"),
+                recv_oct_rate=(c.get("recv_oct_details") or {}).get("rate"),
+            )
+
+    queues = _rmq_get(host, user, password, "queues")
+    if isinstance(queues, list):
+        for q in queues:
+            _emit(
+                out,
+                "rmq_queue",
+                name=q.get("name"),
+                state=q.get("state"),
+                messages=q.get("messages"),
+                messages_ready=q.get("messages_ready"),
+                messages_unack=q.get("messages_unacknowledged"),
+                memory=q.get("memory"),
+                consumers=q.get("consumers"),
+            )
+
+
+def _sample_amqp_socket(out, amqp_port: int) -> None:
+    """ss snapshot of all TCP sockets to/from the broker port."""
+    try:
+        # -t TCP, -n numeric, -i info, -p process. Filter via state filter.
+        r = subprocess.run(
+            [
+                "ss",
+                "-tnpi",
+                f"( sport = :{amqp_port} or dport = :{amqp_port} )",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+        )
+        if r.returncode != 0:
+            _emit(out, "error", source="amqp_sock", err=r.stderr.strip())
+            return
+        lines = r.stdout.strip().splitlines()
+        if len(lines) <= 1:
+            return
+        # Header is line 0; data is line 1+ (and ss prints continuation lines
+        # for the info section). Don't try to parse the info section here —
+        # just stash the raw block per AMQP-direction socket.
+        body = "\n".join(lines[1:])
+        _emit(out, "amqp_sock", raw=body)
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        _emit(out, "error", source="amqp_sock", err=str(e))
+
+
+_LAST_CPU: Optional[List[int]] = None
+
+
+def _sample_sys(out) -> None:
+    """Loadavg + meminfo + cpu steal %."""
+    global _LAST_CPU
+    try:
+        with open("/proc/loadavg") as f:
+            la = f.read().split()
+        with open("/proc/meminfo") as f:
+            mem: Dict[str, int] = {}
+            for line in f:
+                k, _, v = line.partition(":")
+                try:
+                    mem[k.strip()] = int(v.split()[0])
+                except (ValueError, IndexError):
+                    pass
+
+        # CPU steal: read /proc/stat cpu line, diff against previous sample.
+        with open("/proc/stat") as f:
+            cpu_line = f.readline().split()
+        # cpu line: cpu user nice system idle iowait irq softirq steal guest guest_nice
+        cur = [int(x) for x in cpu_line[1:11]]
+        steal_pct = None
+        total_pct = None
+        if _LAST_CPU is not None and len(_LAST_CPU) == len(cur):
+            delta = [c - p for c, p in zip(cur, _LAST_CPU)]
+            total = sum(delta)
+            if total > 0:
+                steal_pct = 100.0 * delta[7] / total
+                total_pct = 100.0 * (total - delta[3]) / total  # everything - idle
+        _LAST_CPU = cur
+
+        _emit(
+            out,
+            "sys",
+            load1=float(la[0]),
+            load5=float(la[1]),
+            mem_available_kb=mem.get("MemAvailable"),
+            mem_total_kb=mem.get("MemTotal"),
+            steal_pct=steal_pct,
+            cpu_pct=total_pct,
+        )
+    except (OSError, ValueError, IndexError) as e:
+        _emit(out, "error", source="sys", err=str(e))
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--pid", type=int, required=True)
+    ap.add_argument("--out", type=Path, required=True)
+    ap.add_argument("--interval", type=float, default=0.5)
+    ap.add_argument("--rabbit-host", default="127.0.0.1")
+    ap.add_argument("--rabbit-user", default="guest")
+    ap.add_argument("--rabbit-pass", default="guest")
+    ap.add_argument("--amqp-port", type=int, default=5672)
+    args = ap.parse_args(argv)
+
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    # Line buffering — every record flushed individually so a SIGKILL'd
+    # monitor leaves a complete file up to the last sample.
+    with open(args.out, "w", buffering=1) as out:
+        _emit(
+            out,
+            "start",
+            pid=args.pid,
+            interval=args.interval,
+            rabbit_host=args.rabbit_host,
+            amqp_port=args.amqp_port,
+        )
+        while _running:
+            t0 = time.monotonic()
+            _sample_proc(out, args.pid)
+            _sample_rmq(out, args.rabbit_host, args.rabbit_user, args.rabbit_pass)
+            _sample_amqp_socket(out, args.amqp_port)
+            _sample_sys(out)
+            # Sleep the remainder of the interval. Pin to wall-clock cadence
+            # rather than fixed sleep so a slow sample doesn't bias the
+            # series.
+            elapsed = time.monotonic() - t0
+            remaining = args.interval - elapsed
+            if remaining > 0:
+                # Sleep in small chunks so SIGTERM unblocks promptly.
+                end = time.monotonic() + remaining
+                while _running and time.monotonic() < end:
+                    time.sleep(min(0.1, end - time.monotonic()))
+        _emit(out, "stop")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
The CA throughput benchmarks (tests/benchmarks/test_bench_ca.py) are currently capped at pop=1024 because the daemon stops processing AI messages part-way through the second step iteration at pop=4096+. Routing itself is fine — iter 1 fans out broadcasts to all subscribers correctly — but at some point the libuv event loop stops draining the AI's TCP socket and no further broadcasts go out. The daemon process stays alive (client connections survive until pytest's drain timeout) but does no visible work until teardown.

Suspected cause: libuv async-write queue cascade as the daemon falls behind feeding 4k+ outbound TCP sockets, possibly coupled with AMQP-CPP outbound saturation. Diagnosis needs strace/perf or temporary instrumentation in NetworkClient::SendDatagram + the AMQP publish path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * CA benchmarks now run larger populations (including 4096) and emit phase-level marks with per-iteration lifecycle tracking and timeouts.
* **New Features**
  * Daemon PID exposed for external monitoring.
  * Added a benchmark sampler and a controllable monitor fixture that records time-series metrics and phase marks.
  * Added a DistributedDirectory test schema object.
* **Bug Fixes / Reliability**
  * More robust outbound networking: queued writes, backpressure limits, and safer shutdown/cleanup.
* **Chores**
  * Updated CI and test container RabbitMQ settings and workflow steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ksmit799/Ardos/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->